### PR TITLE
feat(rag): add phase reference lookup tools

### DIFF
--- a/src/agent/nodes/construction.py
+++ b/src/agent/nodes/construction.py
@@ -12,6 +12,7 @@ from src.agent.nodes._share import (
 from src.agent.react import build_react_agent
 from src.agent.state import AgentState, AgentStateUpdate
 from src.agent.tools import make_construction_tools
+from src.agent.tools.rag_tools import _get_rag
 from src.agent.trace import TraceCollector, record_phase_trace
 
 # Legal back-hop target for construction: a missing material layer hops
@@ -86,7 +87,7 @@ def construction_agent(
     state: AgentState,
 ) -> Command[_ConstructionRoute] | AgentStateUpdate:
     local = clone_for_phase(state)
-    tools = make_construction_tools(local)
+    tools = make_construction_tools(local, rag=_get_rag())
     collector = TraceCollector(phase="construction")
 
     agent = build_react_agent(

--- a/src/agent/nodes/hvac.py
+++ b/src/agent/nodes/hvac.py
@@ -12,6 +12,7 @@ from src.agent.nodes._share import (
 from src.agent.react import build_react_agent
 from src.agent.state import AgentState, AgentStateUpdate
 from src.agent.tools import make_hvac_tools
+from src.agent.tools.rag_tools import _get_rag
 from src.agent.trace import TraceCollector, record_phase_trace
 
 HVAC_SYSTEM_PROMPT = """You are an HVAC configuration expert for EnergyPlus.
@@ -38,6 +39,12 @@ Rules:
   cooling 24 C occupied / 28 C unoccupied.
 - If the spec gives one thermostat for all zones, reuse the same
   template_thermostat_name across all zones.
+
+Reference database:
+- Call search_energyplus_reference with the location and season when design-day
+  values are needed for thermostat or sizing context.
+- Treat returned design-day values as reference context. Do not create
+  SizingPeriod objects unless the specification requests them.
 """
 
 
@@ -49,7 +56,7 @@ _HvacRoute = Literal["zone", "schedule"]
 
 def hvac_agent(state: AgentState) -> Command[_HvacRoute] | AgentStateUpdate:
     local = clone_for_phase(state)
-    tools = make_hvac_tools(local)
+    tools = make_hvac_tools(local, rag=_get_rag())
     collector = TraceCollector(phase="hvac")
 
     agent = build_react_agent(

--- a/src/agent/nodes/material.py
+++ b/src/agent/nodes/material.py
@@ -5,6 +5,7 @@ from src.agent.nodes._share import clone_for_phase, invoke_with_self_repair
 from src.agent.react import build_react_agent
 from src.agent.state import AgentState, AgentStateUpdate
 from src.agent.tools import make_material_tools
+from src.agent.tools.rag_tools import _get_rag
 from src.agent.trace import TraceCollector, record_phase_trace
 
 MATERIAL_SYSTEM_PROMPT = """You are a building material expert for EnergyPlus.
@@ -82,12 +83,18 @@ Rules:
 - Roughness options: VeryRough, Rough, MediumRough, MediumSmooth, Smooth, VerySmooth.
 - Use typical ASHRAE values when the description is vague.
 - Call list_materials once at the end to verify.
+
+Reference database:
+- Call search_energyplus_reference before inventing property values for a named
+  material. Use full_data from the top result for conductivity, density,
+  specific heat, thermal resistance, and other available properties.
+- Use typical ASHRAE values only when the search returns no qualifying match.
 """
 
 
 def material_agent(state: AgentState) -> AgentStateUpdate:
     local = clone_for_phase(state)
-    tools = make_material_tools(local)
+    tools = make_material_tools(local, rag=_get_rag())
     collector = TraceCollector(phase="material")
 
     agent = build_react_agent(

--- a/src/agent/nodes/schedule.py
+++ b/src/agent/nodes/schedule.py
@@ -5,6 +5,7 @@ from src.agent.nodes._share import clone_for_phase, invoke_with_self_repair
 from src.agent.react import build_react_agent
 from src.agent.state import AgentState, AgentStateUpdate
 from src.agent.tools import make_schedule_tools
+from src.agent.tools.rag_tools import _get_rag
 from src.agent.trace import TraceCollector, record_phase_trace
 
 SCHEDULE_SYSTEM_PROMPT = """You are a scheduling expert for EnergyPlus.
@@ -98,12 +99,17 @@ Rules:
 - Cover every day type: either use "AllDays", or use specific day types
   followed by "AllOtherDays" to catch the rest.
 - Call list_schedules once at the end.
+
+Reference database:
+- Call search_energyplus_reference for standard schedule type limit bounds or
+  reference compact schedule profiles for the requested building type.
+- Use returned time-value data as a starting point, then adapt it to the spec.
 """
 
 
 def schedule_agent(state: AgentState) -> AgentStateUpdate:
     local = clone_for_phase(state)
-    tools = make_schedule_tools(local)
+    tools = make_schedule_tools(local, rag=_get_rag())
     collector = TraceCollector(phase="schedule")
 
     agent = build_react_agent(

--- a/src/agent/tools/__init__.py
+++ b/src/agent/tools/__init__.py
@@ -5,6 +5,7 @@ from src.agent.tools.lights_tools import make_lights_tools
 from src.agent.tools.material_tools import make_material_tools
 from src.agent.tools.output_tools import make_output_tools
 from src.agent.tools.people_tools import make_people_tools
+from src.agent.tools.rag_tools import make_rag_tool
 from src.agent.tools.schedule_tools import make_schedule_tools
 from src.agent.tools.surface_tools import make_surface_tools
 from src.agent.tools.zone_tools import make_zone_tools
@@ -17,6 +18,7 @@ __all__ = [
     "make_material_tools",
     "make_output_tools",
     "make_people_tools",
+    "make_rag_tool",
     "make_schedule_tools",
     "make_surface_tools",
     "make_zone_tools",

--- a/src/agent/tools/construction_tools.py
+++ b/src/agent/tools/construction_tools.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 import json
+from typing import TYPE_CHECKING
 
 from idfpy.models.constructions import Construction, ConstructionAirBoundary
 from idfpy.models.thermal_zones import (
@@ -7,7 +10,11 @@ from idfpy.models.thermal_zones import (
 )
 from langchain_core.tools import BaseTool, tool
 
+from src.agent.tools.rag_tools import TABLE_CONSTRUCTIONS, make_rag_tool
 from src.mcp.state import ConfigState
+
+if TYPE_CHECKING:
+    from src.rag.rag import RAGSystem
 
 _LAYER_FIELDS = [
     "outside_layer",
@@ -64,7 +71,10 @@ def _is_airboundary_construction(idf, name: str) -> bool:
     return idf.has("Construction:AirBoundary", name)
 
 
-def make_construction_tools(config: ConfigState) -> list[BaseTool]:
+def make_construction_tools(
+    config: ConfigState,
+    rag: RAGSystem | None = None,
+) -> list[BaseTool]:
     idf = config.idf
 
     @tool
@@ -258,7 +268,7 @@ def make_construction_tools(config: ConfigState) -> list[BaseTool]:
                 items.append({"type": t, **obj.model_dump()})
         return _ok(f"Listed {len(items)} materials.", items)
 
-    return [
+    tools = [
         create_construction,
         create_airboundary_construction,
         list_constructions,
@@ -267,3 +277,6 @@ def make_construction_tools(config: ConfigState) -> list[BaseTool]:
         delete_construction,
         list_materials,
     ]
+    if rag is not None:
+        tools.append(make_rag_tool([TABLE_CONSTRUCTIONS], rag=rag))
+    return tools

--- a/src/agent/tools/hvac_tools.py
+++ b/src/agent/tools/hvac_tools.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 import json
+from typing import TYPE_CHECKING
 
 from idfpy.models.hvac_templates import (
     HVACTemplateThermostat,
@@ -8,7 +11,11 @@ from idfpy.models.schedules import ScheduleCompact
 from idfpy.models.thermal_zones import Zone
 from langchain_core.tools import BaseTool, tool
 
+from src.agent.tools.rag_tools import TABLE_SIZING_PERIOD_DESIGN_DAY, make_rag_tool
 from src.mcp.state import ConfigState
+
+if TYPE_CHECKING:
+    from src.rag.rag import RAGSystem
 
 
 def _ok(msg: str, data=None) -> str:
@@ -19,7 +26,10 @@ def _err(msg: str, data=None) -> str:
     return json.dumps({"success": False, "message": msg, "data": data})
 
 
-def make_hvac_tools(config: ConfigState) -> list[BaseTool]:
+def make_hvac_tools(
+    config: ConfigState,
+    rag: RAGSystem | None = None,
+) -> list[BaseTool]:
     idf = config.idf
 
     @tool
@@ -200,7 +210,7 @@ def make_hvac_tools(config: ConfigState) -> list[BaseTool]:
         items = [s.model_dump() for s in idf.all_of_type(ScheduleCompact).values()]
         return _ok(f"Listed {len(items)} schedules.", items)
 
-    return [
+    tools = [
         create_thermostat,
         create_ideal_loads_system,
         list_thermostats,
@@ -212,3 +222,6 @@ def make_hvac_tools(config: ConfigState) -> list[BaseTool]:
         list_zones,
         list_schedules,
     ]
+    if rag is not None:
+        tools.append(make_rag_tool([TABLE_SIZING_PERIOD_DESIGN_DAY], rag=rag))
+    return tools

--- a/src/agent/tools/material_tools.py
+++ b/src/agent/tools/material_tools.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 import json
+from typing import TYPE_CHECKING
 
 from idfpy.models.constructions import (
     Construction,
@@ -10,7 +13,16 @@ from idfpy.models.constructions import (
 )
 from langchain_core.tools import BaseTool, tool
 
+from src.agent.tools.rag_tools import (
+    TABLE_ALL_MATERIALS,
+    TABLE_NO_MASS_MATERIALS,
+    TABLE_STANDARD_MATERIALS,
+    make_rag_tool,
+)
 from src.mcp.state import ConfigState
+
+if TYPE_CHECKING:
+    from src.rag.rag import RAGSystem
 
 # idfpy object-type strings for each material variant
 _ALL_MATERIAL_TYPES = [
@@ -39,7 +51,10 @@ def _find_material(idf, name: str):
     return None, None
 
 
-def make_material_tools(config: ConfigState) -> list[BaseTool]:
+def make_material_tools(
+    config: ConfigState,
+    rag: RAGSystem | None = None,
+) -> list[BaseTool]:
     idf = config.idf
 
     @tool
@@ -381,7 +396,7 @@ def make_material_tools(config: ConfigState) -> list[BaseTool]:
         idf.remove(mat_type, name)
         return _ok(f"Material '{name}' deleted successfully.")
 
-    return [
+    tools = [
         create_standard_material,
         create_nomass_material,
         create_airgap_material,
@@ -392,3 +407,15 @@ def make_material_tools(config: ConfigState) -> list[BaseTool]:
         update_material,
         delete_material,
     ]
+    if rag is not None:
+        tools.append(
+            make_rag_tool(
+                [
+                    TABLE_STANDARD_MATERIALS,
+                    TABLE_NO_MASS_MATERIALS,
+                    TABLE_ALL_MATERIALS,
+                ],
+                rag=rag,
+            )
+        )
+    return tools

--- a/src/agent/tools/rag_tools.py
+++ b/src/agent/tools/rag_tools.py
@@ -1,0 +1,208 @@
+"""RAG reference lookup tools for EnergyPlus phase agents.
+
+RAGSystem is initialized once at first call via a lazy singleton (_get_rag).
+If initialization fails (missing env vars, unreachable Qdrant/Gemini), _rag is
+set to None and all RAG tools return a graceful "unavailable" response so the
+rest of the agent pipeline is unaffected.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import TYPE_CHECKING, Final
+
+from dotenv import load_dotenv
+from langchain_core.tools import BaseTool, tool
+
+from src.utils.logging import get_logger
+
+if TYPE_CHECKING:
+    from src.rag.rag import RAGSystem
+
+load_dotenv()
+_logger = get_logger(__name__)
+
+# ── Lazy singleton ────────────────────────────────────────────────────────────
+
+_rag: RAGSystem | None = None
+_rag_attempted: bool = False
+
+
+def _get_rag() -> RAGSystem | None:
+    """Return the shared RAGSystem instance, initializing it on first call.
+
+    Returns None (without raising) if env vars are missing or init fails.
+    The _rag_attempted flag ensures a failed init is not retried on every
+    node invocation inside a hot LangGraph parallel branch.
+    """
+    global _rag, _rag_attempted
+    if _rag_attempted:
+        return _rag
+    _rag_attempted = True
+
+    qdrant_url = os.getenv("QDRANT_ENDPOINT", "")
+    qdrant_api_key = os.getenv("QDRANT_API_KEY", "")
+    qdrant_collection = os.getenv("QDRANT_COLLECTION_NAME", "energyplus_database")
+    gemini_api_key = os.getenv("GEMINI_API_KEY", "")
+
+    if not (qdrant_url and gemini_api_key):
+        _logger.warning(
+            "RAG unavailable: QDRANT_ENDPOINT or GEMINI_API_KEY is not set. "
+            "Phase agents will use ASHRAE default values."
+        )
+        return None
+
+    try:
+        from src.rag.rag import RAGSystem  # local import to keep startup fast
+
+        _rag = RAGSystem(
+            qdrant_url=qdrant_url,
+            qdrant_api_key=qdrant_api_key,
+            qdrant_collection_name=qdrant_collection,
+            gemini_api_key=gemini_api_key,
+        )
+        _logger.info("RAGSystem initialized (collection={})", qdrant_collection)
+    except Exception as exc:
+        _logger.warning("RAGSystem initialization failed: {}. RAG tools disabled.", exc)
+    return _rag
+
+
+# ── Table name constants ──────────────────────────────────────────────────────
+
+TABLE_STANDARD_MATERIALS: Final = "standard_materials"
+TABLE_NO_MASS_MATERIALS: Final = "no_mass_materials"
+TABLE_ALL_MATERIALS: Final = "all_materials"
+TABLE_CONSTRUCTIONS: Final = "constructions"
+TABLE_SCHEDULE_TYPE_LIMITS: Final = "schedule_type_limits"
+TABLE_SCHEDULE_COMPACT: Final = "schedule_compact"
+TABLE_SIZING_PERIOD_DESIGN_DAY: Final = "sizingperiod_designday"
+
+
+# ── Tool factory ──────────────────────────────────────────────────────────────
+
+
+def make_rag_tool(
+    allowed_tables: list[str] | None = None,
+    top_k: int = 5,
+    score_threshold: float = 0.5,
+    rag: RAGSystem | None = None,
+) -> BaseTool:
+    """Build a ``search_energyplus_reference`` tool pre-scoped to *allowed_tables*.
+
+    Args:
+        allowed_tables: Tables to search. Searches are merged and re-ranked by
+            cosine score. Pass None to search across all tables.
+        top_k: Maximum number of results to return.
+        score_threshold: Minimum cosine similarity (0.0-1.0).
+        rag: RAGSystem instance to use. If None, the module-level singleton is
+            used (obtained via _get_rag()). Pass an explicit instance for testing.
+    """
+    if rag is None:
+        rag = _get_rag()  # lazy singleton — may return None if unavailable
+
+    @tool
+    def search_energyplus_reference(query: str) -> str:
+        """Search the EnergyPlus reference database for material properties,
+        construction assemblies, schedule profiles, or design-day parameters.
+
+        Call this tool BEFORE inventing property values when you need:
+        - Thermal properties for a named material (conductivity, density,
+          specific heat, R-value, roughness)
+        - Standard construction layer sequences (outside → inside order)
+        - Schedule type limit bounds or reference compact schedule profiles
+        - Design-day meteorological parameters for HVAC sizing
+
+        Args:
+            query: Natural-language description of what you are looking for.
+                   Be specific — include material name, building type, climate
+                   zone, or parameter names. Examples:
+                     'thermal conductivity of normal weight concrete 200 mm'
+                     'standard exterior wall assembly brick insulation'
+                     'medium office occupancy fraction schedule weekday'
+                     'summer design day dry bulb temperature Beijing'
+
+        Returns:
+            JSON with a list of matching records, each containing:
+            description, table_name, record_id, score (cosine similarity),
+            and full_data with all EnergyPlus property values.
+            Use the full_data fields as authoritative values instead of guessing.
+            If no match is found (empty list or success=false), fall back to
+            ASHRAE typical values and proceed.
+        """
+        if rag is None:
+            return json.dumps(
+                {
+                    "success": False,
+                    "message": (
+                        "EnergyPlus reference database is unavailable. "
+                        "Use ASHRAE default values and proceed."
+                    ),
+                    "data": None,
+                }
+            )
+
+        try:
+            results = []
+            if allowed_tables:
+                for table in allowed_tables:
+                    hits = rag.search(
+                        query=query,
+                        top_k=top_k,
+                        chunk_type=table,
+                        score_threshold=score_threshold,
+                    )
+                    results.extend(hits)
+                results.sort(key=lambda r: r.score or 0.0, reverse=True)
+                results = results[:top_k]
+            else:
+                results = rag.search(
+                    query=query,
+                    top_k=top_k,
+                    chunk_type=None,
+                    score_threshold=score_threshold,
+                )
+
+            if not results:
+                return json.dumps(
+                    {
+                        "success": True,
+                        "message": (
+                            "No matching records found in the EnergyPlus reference "
+                            "database. Use ASHRAE default values and proceed."
+                        ),
+                        "data": [],
+                    }
+                )
+
+            records = [
+                {
+                    "description": r.description,
+                    "table_name": r.table_name,
+                    "record_id": r.record_id,
+                    "score": round(r.score or 0.0, 4),
+                    "full_data": r.full_data,
+                }
+                for r in results
+            ]
+            return json.dumps(
+                {
+                    "success": True,
+                    "message": f"Found {len(records)} matching EnergyPlus reference records.",
+                    "data": records,
+                }
+            )
+
+        except Exception as exc:
+            return json.dumps(
+                {
+                    "success": False,
+                    "message": (
+                        f"RAG query failed: {exc}. "
+                        "Use ASHRAE default values and proceed."
+                    ),
+                    "data": None,
+                }
+            )
+
+    return search_energyplus_reference

--- a/src/agent/tools/schedule_tools.py
+++ b/src/agent/tools/schedule_tools.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import json
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from idfpy.models.hvac_templates import (
     HVACTemplateThermostat,
@@ -13,7 +15,15 @@ from idfpy.models.schedules import (
 )
 from langchain_core.tools import BaseTool, tool
 
+from src.agent.tools.rag_tools import (
+    TABLE_SCHEDULE_COMPACT,
+    TABLE_SCHEDULE_TYPE_LIMITS,
+    make_rag_tool,
+)
 from src.mcp.state import ConfigState
+
+if TYPE_CHECKING:
+    from src.rag.rag import RAGSystem
 from src.validator.data_model import ScheduleCompactSchema
 
 
@@ -25,7 +35,10 @@ def _err(msg: str, data=None) -> str:
     return json.dumps({"success": False, "message": msg, "data": data})
 
 
-def make_schedule_tools(config: ConfigState) -> list[BaseTool]:
+def make_schedule_tools(
+    config: ConfigState,
+    rag: RAGSystem | None = None,
+) -> list[BaseTool]:
     idf = config.idf
 
     @tool
@@ -230,7 +243,7 @@ def make_schedule_tools(config: ConfigState) -> list[BaseTool]:
         idf.remove("Schedule:Compact", name)
         return _ok(f"Schedule:Compact '{name}' deleted successfully.")
 
-    return [
+    tools = [
         create_schedule_type_limits,
         create_schedule_compact,
         list_schedules,
@@ -239,3 +252,11 @@ def make_schedule_tools(config: ConfigState) -> list[BaseTool]:
         update_schedule_compact,
         delete_schedule,
     ]
+    if rag is not None:
+        tools.append(
+            make_rag_tool(
+                [TABLE_SCHEDULE_TYPE_LIMITS, TABLE_SCHEDULE_COMPACT],
+                rag=rag,
+            )
+        )
+    return tools

--- a/tests/agent/nodes/test_rag_registration.py
+++ b/tests/agent/nodes/test_rag_registration.py
@@ -1,0 +1,75 @@
+from types import ModuleType
+from typing import Any
+
+import pytest
+from langchain_core.messages import AIMessage
+from pytest import MonkeyPatch
+
+from src.agent.nodes import construction, hvac, material, schedule
+from src.agent.state import AgentState
+from src.mcp.state import ConfigState
+
+
+class _FakeTraceCollector:
+    def __init__(self, phase: str) -> None:
+        self.phase = phase
+
+    def export(self) -> dict[str, str]:
+        return {"phase": self.phase}
+
+
+def _assert_agent_registers_rag(
+    monkeypatch: MonkeyPatch,
+    module: ModuleType,
+    agent_name: str,
+    factory_name: str,
+) -> None:
+    local = ConfigState()
+    fake_rag = object()
+    captured: dict[str, Any] = {}
+
+    def fake_make_tools(config: ConfigState, rag: object | None = None) -> list[Any]:
+        captured["factory"] = {"config": config, "rag": rag}
+        return []
+
+    def fake_build_react_agent(**kwargs: Any) -> object:
+        captured["build"] = kwargs
+        return object()
+
+    monkeypatch.setattr(module, "clone_for_phase", lambda state: local)
+    monkeypatch.setattr(module, "_get_rag", lambda: fake_rag, raising=False)
+    monkeypatch.setattr(module, factory_name, fake_make_tools)
+    monkeypatch.setattr(module, "create_llm", lambda: object())
+    monkeypatch.setattr(module, "build_react_agent", fake_build_react_agent)
+    monkeypatch.setattr(module, "TraceCollector", _FakeTraceCollector)
+    monkeypatch.setattr(module, "record_phase_trace", lambda *args: None)
+    monkeypatch.setattr(
+        module,
+        "invoke_with_self_repair",
+        lambda *args, **kwargs: {"messages": [AIMessage(content="done")]},
+    )
+    if hasattr(module, "maybe_backhop"):
+        monkeypatch.setattr(module, "maybe_backhop", lambda *args: None)
+
+    getattr(module, agent_name)(AgentState(user_input="spec"))
+
+    assert captured["factory"] == {"config": local, "rag": fake_rag}
+    assert "search_energyplus_reference" in captured["build"]["system_prompt"]
+
+
+@pytest.mark.parametrize(
+    ("module", "agent_name", "factory_name"),
+    [
+        (material, "material_agent", "make_material_tools"),
+        (construction, "construction_agent", "make_construction_tools"),
+        (schedule, "schedule_agent", "make_schedule_tools"),
+        (hvac, "hvac_agent", "make_hvac_tools"),
+    ],
+)
+def test_phase_agents_register_rag_search(
+    monkeypatch: MonkeyPatch,
+    module: ModuleType,
+    agent_name: str,
+    factory_name: str,
+) -> None:
+    _assert_agent_registers_rag(monkeypatch, module, agent_name, factory_name)

--- a/tests/agent/tools/test_rag_tools.py
+++ b/tests/agent/tools/test_rag_tools.py
@@ -1,0 +1,151 @@
+import json
+from dataclasses import dataclass
+from typing import Any, cast
+
+import pytest
+from _pytest.monkeypatch import MonkeyPatch
+
+from src.agent.tools import (
+    make_construction_tools,
+    make_hvac_tools,
+    make_material_tools,
+    make_schedule_tools,
+    rag_tools,
+)
+from src.mcp.state import ConfigState
+
+
+@dataclass
+class _SearchResult:
+    description: str
+    table_name: str
+    record_id: str
+    score: float
+    full_data: dict[str, Any]
+
+
+class _FakeRag:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, int, str | None, float]] = []
+
+    def search(
+        self,
+        *,
+        query: str,
+        top_k: int,
+        chunk_type: str | None,
+        score_threshold: float,
+    ) -> list[_SearchResult]:
+        self.calls.append((query, top_k, chunk_type, score_threshold))
+        results = {
+            "materials": [
+                _SearchResult(
+                    description="Concrete",
+                    table_name="materials",
+                    record_id="material-low",
+                    score=0.61,
+                    full_data={"conductivity": 1.4},
+                )
+            ],
+            "constructions": [
+                _SearchResult(
+                    description="Insulated wall",
+                    table_name="constructions",
+                    record_id="construction-high",
+                    score=0.93456,
+                    full_data={"layers": ["brick", "insulation"]},
+                ),
+                _SearchResult(
+                    description="Mass wall",
+                    table_name="constructions",
+                    record_id="construction-mid",
+                    score=0.72,
+                    full_data={"layers": ["concrete"]},
+                ),
+            ],
+        }
+        return results.get(chunk_type or "", [])
+
+
+def test_rag_tool_reports_unavailable_without_credentials(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("QDRANT_ENDPOINT", raising=False)
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.setattr(rag_tools, "_rag", None)
+    monkeypatch.setattr(rag_tools, "_rag_attempted", False)
+
+    result = json.loads(rag_tools.make_rag_tool().invoke({"query": "wall assembly"}))
+
+    assert result == {
+        "success": False,
+        "message": (
+            "EnergyPlus reference database is unavailable. "
+            "Use ASHRAE default values and proceed."
+        ),
+        "data": None,
+    }
+
+
+def test_rag_tool_merges_allowed_tables_by_score() -> None:
+    fake_rag = _FakeRag()
+    tool = rag_tools.make_rag_tool(
+        allowed_tables=["materials", "constructions"],
+        top_k=2,
+        score_threshold=0.5,
+        rag=cast(Any, fake_rag),
+    )
+
+    result = json.loads(tool.invoke({"query": "exterior wall"}))
+
+    assert result["success"] is True
+    assert [record["record_id"] for record in result["data"]] == [
+        "construction-high",
+        "construction-mid",
+    ]
+    assert result["data"][0]["score"] == 0.9346
+    assert fake_rag.calls == [
+        ("exterior wall", 2, "materials", 0.5),
+        ("exterior wall", 2, "constructions", 0.5),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("factory", "expected_tables"),
+    [
+        (
+            make_material_tools,
+            ["standard_materials", "no_mass_materials", "all_materials"],
+        ),
+        (make_construction_tools, ["constructions"]),
+        (make_schedule_tools, ["schedule_type_limits", "schedule_compact"]),
+        (make_hvac_tools, ["sizingperiod_designday"]),
+    ],
+)
+def test_phase_tool_factories_scope_rag_search(
+    factory: Any,
+    expected_tables: list[str],
+) -> None:
+    fake_rag = _FakeRag()
+
+    tools = factory(ConfigState(), rag=cast(Any, fake_rag))
+
+    assert [tool.name for tool in tools].count("search_energyplus_reference") == 1
+    result = json.loads(tools[-1].invoke({"query": "reference query"}))
+    assert result["success"] is True
+    assert [call[2] for call in fake_rag.calls] == expected_tables
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        make_material_tools,
+        make_construction_tools,
+        make_schedule_tools,
+        make_hvac_tools,
+    ],
+)
+def test_phase_tool_factories_omit_rag_search_when_unavailable(factory: Any) -> None:
+    tools = factory(ConfigState(), rag=None)
+
+    assert "search_energyplus_reference" not in [tool.name for tool in tools]


### PR DESCRIPTION
## Summary

- add a lazy, failure-isolated EnergyPlus reference lookup tool
- register scoped RAG search with material, construction, schedule, and HVAC phases
- inject reference lookup guidance into phase prompts
- keep normal agent tools available when RAG initialization is unavailable

## Stack

Depends on `chore/pr51-quality`. This PR contains only the RAG integration layer and its tests.

## Validation

- `uv run pre-commit run --all-files`: passed
- RAG tests: 14 passed
- offline suite: 67 passed, 1 credential-dependent test deselected