### PR TITLE
fix(fenestration): harden window modeling

### DIFF
--- a/src/agent/nodes/construction.py
+++ b/src/agent/nodes/construction.py
@@ -39,6 +39,21 @@ Rules:
   (e.g., 'ExtWall_Office', 'IntWall_Office', 'Roof_Office', 'Floor_Office',
   'Window_Office').
 - For fenestration, the construction's only layer is the glazing material.
+- INTERIOR doors/windows/glass-doors between two zones (hosted on a wall that
+  separates zones, i.e. the wall's outside boundary condition is 'Surface'):
+  use create_airboundary_construction (a Construction:AirBoundary, no layers).
+  This models the door/window as an OPEN passage between zones and avoids the
+  EnergyPlus error "invalid blank Outside Boundary Condition Object" that a
+  regular layered construction would trigger there. Name it e.g.
+  'Interior_Door_Open'. EXTERIOR doors/windows still use a normal layered
+  Construction (glazing for windows, opaque for doors).
+
+Reference database:
+- Call search_energyplus_reference to look up standard layer sequences for
+  named construction types (e.g. 'ASHRAE 90.1 exterior wall office').
+  Match returned layer names to existing materials via list_materials;
+  if a reference layer has no local equivalent, use the nearest match by
+  thermal properties.
 """
 
 

--- a/src/agent/nodes/construction.py
+++ b/src/agent/nodes/construction.py
@@ -39,6 +39,20 @@ Rules:
   (e.g., 'ExtWall_Office', 'IntWall_Office', 'Roof_Office', 'Floor_Office',
   'Window_Office').
 - For fenestration, the construction's only layer is the glazing material.
+- FENESTRATION GLAZING RULE — two legal window construction shapes ONLY:
+  1. SINGLE-LAYER whole window: one WindowMaterial:SimpleGlazingSystem layer
+     (created via create_glazing_material). The construction has exactly ONE
+     layer. This is invalid for multi-pane windows.
+  2. MULTI-LAYER real assembly: per-pane WindowMaterial:Glazing layers
+     (created via create_glazing_layer_material) interleaved with
+     Material:AirGap, e.g. layers=['Clear_Glass_3mm','Air_Gap_13mm',
+     'Clear_Glass_3mm'] for a double-pane window.
+  NEVER mix WindowMaterial:SimpleGlazingSystem with other layers (gas gaps,
+  extra panes). SimpleGlazingSystem is a whole-window equivalent
+  (U/SHGC/VT only) — combining it with other layers gives EnergyPlus no
+  per-pane data and aborts with a Fatal convergence error. If the spec wants
+  a double/triple-pane window, the material phase MUST supply
+  WindowMaterial:Glazing panes (not SimpleGlazingSystem).
 - INTERIOR doors/windows/glass-doors between two zones (hosted on a wall that
   separates zones, i.e. the wall's outside boundary condition is 'Surface'):
   use create_airboundary_construction (a Construction:AirBoundary, no layers).

--- a/src/agent/nodes/construction.py
+++ b/src/agent/nodes/construction.py
@@ -39,20 +39,28 @@ Rules:
   (e.g., 'ExtWall_Office', 'IntWall_Office', 'Roof_Office', 'Floor_Office',
   'Window_Office').
 - For fenestration, the construction's only layer is the glazing material.
-- FENESTRATION GLAZING RULE — two legal window construction shapes ONLY:
-  1. SINGLE-LAYER whole window: one WindowMaterial:SimpleGlazingSystem layer
-     (created via create_glazing_material). The construction has exactly ONE
-     layer. This is invalid for multi-pane windows.
-  2. MULTI-LAYER real assembly: per-pane WindowMaterial:Glazing layers
-     (created via create_glazing_layer_material) interleaved with
-     Material:AirGap, e.g. layers=['Clear_Glass_3mm','Air_Gap_13mm',
-     'Clear_Glass_3mm'] for a double-pane window.
+- FENESTRATION GLAZING RULE — DEFAULT TO SINGLE-LAYER SimpleGlazingSystem:
+  1. PREFERRED: a SINGLE-LAYER whole window whose only layer is a
+     WindowMaterial:SimpleGlazingSystem (created via create_glazing_material).
+     Use this for ALL windows unless the material phase has explicitly
+     created per-pane WindowMaterial:Glazing layers. Even for "double pane"
+     or "triple pane" specs, prefer this — the material phase should have
+     supplied an equivalent whole-window U-factor/SHGC via
+     create_glazing_material. The construction has exactly ONE layer.
+  2. MULTI-LAYER real assembly (ONLY if per-pane layers already exist):
+     per-pane WindowMaterial:Glazing layers (created via
+     create_glazing_layer_material) interleaved with Material:AirGap, e.g.
+     layers=['Clear_Glass_3mm','Air_Gap_13mm','Clear_Glass_3mm']. Use this
+     shape ONLY when list_materials shows WindowMaterial:Glazing objects;
+     otherwise fall back to single-layer SimpleGlazingSystem.
   NEVER mix WindowMaterial:SimpleGlazingSystem with other layers (gas gaps,
   extra panes). SimpleGlazingSystem is a whole-window equivalent
   (U/SHGC/VT only) — combining it with other layers gives EnergyPlus no
-  per-pane data and aborts with a Fatal convergence error. If the spec wants
-  a double/triple-pane window, the material phase MUST supply
-  WindowMaterial:Glazing panes (not SimpleGlazingSystem).
+  per-pane data and aborts with a Fatal convergence error.
+  DECISION RULE: if list_materials contains a WindowMaterial:SimpleGlazingSystem,
+  use it as the sole layer of the window construction. Only assemble
+  per-pane layers if the spec explicitly provided per-pane optical data AND
+  the material phase created WindowMaterial:Glazing objects.
 - INTERIOR doors/windows/glass-doors between two zones (hosted on a wall that
   separates zones, i.e. the wall's outside boundary condition is 'Surface'):
   use create_airboundary_construction (a Construction:AirBoundary, no layers).

--- a/src/agent/nodes/fenestration.py
+++ b/src/agent/nodes/fenestration.py
@@ -51,6 +51,13 @@ Rules:
   rejected. If the only window construction available is opaque, STOP and
   report — do not create the fenestration against it; the material phase
   must first create a WindowMaterial and construction must rebuild it.
+- INTERIOR doors/windows (parent wall's outside boundary condition is
+  'Surface' — i.e. it separates two zones) MUST use a Construction:AirBoundary
+  (created via create_airboundary_construction). A regular layered
+  construction on an interior subsurface leaves its boundary object blank
+  and aborts EnergyPlus. Before creating, check the parent surface's
+  boundary condition in list_surfaces: if it is 'Surface', request/reuse an
+  AirBoundary construction for that door/window.
 - surface_type is Window, Door, or GlassDoor.
 - >= 3 vertices and MUST lie on the parent surface's plane (coplanar —
   share one coordinate for walls). Winding direction does not matter —

--- a/src/agent/nodes/fenestration.py
+++ b/src/agent/nodes/fenestration.py
@@ -45,12 +45,14 @@ Rules:
 - If a needed surface or construction is missing after list, STOP and
   report; do NOT invent names.
 - For Window / GlassDoor / TubularDaylight* the construction MUST be a
-  glazing construction — one whose layers include a
-  WindowMaterial:SimpleGlazingSystem. An opaque construction (only
-  Material / Material:NoMass layers) is invalid for windows and will be
-  rejected. If the only window construction available is opaque, STOP and
-  report — do not create the fenestration against it; the material phase
-  must first create a WindowMaterial and construction must rebuild it.
+  glazing construction — one whose layers include a WindowMaterial
+  (WindowMaterial:SimpleGlazingSystem as the sole layer, OR
+  WindowMaterial:Glazing panes possibly with Material:AirGap). An opaque
+  construction (only Material / Material:NoMass layers) is invalid for
+  windows and will be rejected. If the only window construction available
+  is opaque, STOP and report — do not create the fenestration against it;
+  the material phase must first create a WindowMaterial and construction
+  must rebuild it.
 - INTERIOR doors/windows (parent wall's outside boundary condition is
   'Surface' — i.e. it separates two zones) MUST use a Construction:AirBoundary
   (created via create_airboundary_construction). A regular layered

--- a/src/agent/nodes/fenestration.py
+++ b/src/agent/nodes/fenestration.py
@@ -44,10 +44,17 @@ Rules:
   in the list_surfaces / list_constructions results.
 - If a needed surface or construction is missing after list, STOP and
   report; do NOT invent names.
-- construction_name should be a Glazing construction for windows/skylights.
-- >= 3 vertices, counter-clockwise from OUTSIDE, and MUST lie on the
-  parent surface's plane (coplanar — share one coordinate for walls).
+- For Window / GlassDoor / TubularDaylight* the construction MUST be a
+  glazing construction — one whose layers include a
+  WindowMaterial:SimpleGlazingSystem. An opaque construction (only
+  Material / Material:NoMass layers) is invalid for windows and will be
+  rejected. If the only window construction available is opaque, STOP and
+  report — do not create the fenestration against it; the material phase
+  must first create a WindowMaterial and construction must rebuild it.
 - surface_type is Window, Door, or GlassDoor.
+- >= 3 vertices and MUST lie on the parent surface's plane (coplanar —
+  share one coordinate for walls). Winding direction does not matter —
+  the tool auto-aligns the window's outward normal to the parent wall's.
 - Typical window-to-wall ratio: 0.3-0.4 on facade walls; derive vertex
   coordinates from the parent wall's corners and the WWR.
 - Naming: '{parent_surface}_Window' or '{zone}_{direction}_Window_{index}'.

--- a/src/agent/nodes/material.py
+++ b/src/agent/nodes/material.py
@@ -16,22 +16,47 @@ Choose the correct material type:
   conductivity (W/m-K), density (kg/m^3), specific heat (J/kg-K).
 - create_nomass_material when only R-value is known (thin finishes, membranes).
 - create_airgap_material for enclosed air cavities in wall/roof assemblies.
-- create_glazing_material for ALL transparent/translucent glazing: windows,
-  skylights, glass doors, and any "glass" / "glazing" material. Supply
-  u_factor (W/m^2-K), solar_heat_gain_coefficient (0-1), optional
-  visible_transmittance (0-1).
+- create_glazing_material for a SIMPLIFIED whole-window model: use this
+  when the spec gives an overall U-factor / SHGC / VT for the whole
+  window (single pane OR a pre-computed assembly equivalent). This
+  produces a WindowMaterial:SimpleGlazingSystem that MUST be the ONLY
+  layer of its construction — it cannot be combined with gas gaps or
+  other panes (see CRITICAL rule below).
+- create_glazing_layer_material for a TRUE per-pane glass layer
+  (WindowMaterial:Glazing): use this when you need to assemble a
+  multi-pane (double/triple) window from individual glass panes + air
+  gaps. It carries thickness + per-pane optical/thermal data, so it CAN
+  be composed with create_airgap_material in a layered construction.
+  Supply thickness (m), solar_transmittance, visible_transmittance,
+  conductivity (W/m-K); other optical fields have sensible defaults.
 
 CRITICAL — GLASS MUST BE A WINDOWMATERIAL, NEVER AN OPAQUE MATERIAL:
 - Any material described as glass / glazing / window-pane / clear or tinted
   transparent layer (e.g. 'Float_Glass', 'Single_Glazing', 'Double_Pane')
-  MUST be created with create_glazing_material. This produces a
-  WindowMaterial:SimpleGlazingSystem object.
-- DO NOT create glass with create_standard_material or create_nomass_material.
-  An opaque Material named 'Float_Glass' will make EnergyPlus abort with
+  MUST be created with create_glazing_material (whole-window) OR
+  create_glazing_layer_material (per-pane). NEVER use create_standard_material
+  or create_nomass_material for glass.
+- An opaque Material named 'Float_Glass' will make EnergyPlus abort with
   "FenestrationSurface has an opaque surface construction; it should have a
   window construction". A glazing construction REQUIRES a WindowMaterial layer.
 - Rule of thumb: if the material is meant to be seen through or admits
-  daylight, it is glazing -> create_glazing_material.
+  daylight, it is glazing.
+
+CRITICAL — SimpleGlazingSystem IS A WHOLE-WINDOW MODEL, NOT A PANE:
+- WindowMaterial:SimpleGlazingSystem (from create_glazing_material) collapses
+  the ENTIRE window into one U-factor/SHGC/VT object. It MUST be the SOLE
+  layer of its construction. Combining it with other layers — e.g.
+  [SimpleGlazingSystem + AirGap + SimpleGlazingSystem] for a "double pane" —
+  is INVALID: EnergyPlus has no per-pane optical data and aborts with a Fatal
+  "Convergence error in SolveForWindowTemperatures" (NaN glass temperatures).
+- To build a REAL double/triple-pane window, use per-pane glass layers:
+    1. create_glazing_layer_material for each pane (e.g. 'Clear_Glass_3mm'),
+    2. create_airgap_material for the gap (e.g. 'Air_Gap_13mm'),
+    3. construction phase: create_construction(layers=['Clear_Glass_3mm',
+       'Air_Gap_13mm', 'Clear_Glass_3mm']).
+- Quick decision: if the spec gives a single U-factor/SHGC for the window,
+  use create_glazing_material (one layer). If it describes pane thicknesses
+  or a multi-pane makeup, use create_glazing_layer_material (layered).
 
 Rules:
 - Material names must be unique and self-describing (e.g., 'Brick_100mm',

--- a/src/agent/nodes/material.py
+++ b/src/agent/nodes/material.py
@@ -16,8 +16,22 @@ Choose the correct material type:
   conductivity (W/m-K), density (kg/m^3), specific heat (J/kg-K).
 - create_nomass_material when only R-value is known (thin finishes, membranes).
 - create_airgap_material for enclosed air cavities in wall/roof assemblies.
-- create_glazing_material for simplified windows: supply u_factor (W/m^2-K),
-  solar_heat_gain_coefficient (0-1), optional visible_transmittance (0-1).
+- create_glazing_material for ALL transparent/translucent glazing: windows,
+  skylights, glass doors, and any "glass" / "glazing" material. Supply
+  u_factor (W/m^2-K), solar_heat_gain_coefficient (0-1), optional
+  visible_transmittance (0-1).
+
+CRITICAL — GLASS MUST BE A WINDOWMATERIAL, NEVER AN OPAQUE MATERIAL:
+- Any material described as glass / glazing / window-pane / clear or tinted
+  transparent layer (e.g. 'Float_Glass', 'Single_Glazing', 'Double_Pane')
+  MUST be created with create_glazing_material. This produces a
+  WindowMaterial:SimpleGlazingSystem object.
+- DO NOT create glass with create_standard_material or create_nomass_material.
+  An opaque Material named 'Float_Glass' will make EnergyPlus abort with
+  "FenestrationSurface has an opaque surface construction; it should have a
+  window construction". A glazing construction REQUIRES a WindowMaterial layer.
+- Rule of thumb: if the material is meant to be seen through or admits
+  daylight, it is glazing -> create_glazing_material.
 
 Rules:
 - Material names must be unique and self-describing (e.g., 'Brick_100mm',

--- a/src/agent/nodes/material.py
+++ b/src/agent/nodes/material.py
@@ -16,26 +16,46 @@ Choose the correct material type:
   conductivity (W/m-K), density (kg/m^3), specific heat (J/kg-K).
 - create_nomass_material when only R-value is known (thin finishes, membranes).
 - create_airgap_material for enclosed air cavities in wall/roof assemblies.
-- create_glazing_material for a SIMPLIFIED whole-window model: use this
-  when the spec gives an overall U-factor / SHGC / VT for the whole
-  window (single pane OR a pre-computed assembly equivalent). This
-  produces a WindowMaterial:SimpleGlazingSystem that MUST be the ONLY
-  layer of its construction — it cannot be combined with gas gaps or
-  other panes (see CRITICAL rule below).
+- create_glazing_material for a SIMPLIFIED whole-window model. This is the
+  DEFAULT and PREFERRED way to model windows. Use it whenever the spec
+  gives an overall U-factor / SHGC / VT (or even just a qualitative
+  description like "double-glazed", "low-e", "clear glass"). It produces a
+  WindowMaterial:SimpleGlazingSystem that is numerically robust and will
+  NOT trigger EnergyPlus convergence errors. MUST be the ONLY layer of its
+  construction — it cannot be combined with gas gaps or other panes.
 - create_glazing_layer_material for a TRUE per-pane glass layer
-  (WindowMaterial:Glazing): use this when you need to assemble a
-  multi-pane (double/triple) window from individual glass panes + air
-  gaps. It carries thickness + per-pane optical/thermal data, so it CAN
-  be composed with create_airgap_material in a layered construction.
-  Supply thickness (m), solar_transmittance, visible_transmittance,
-  conductivity (W/m-K); other optical fields have sensible defaults.
+  (WindowMaterial:Glazing). AVOID THIS unless the spec explicitly gives
+  per-pane physical parameters (glass thickness + solar/visible
+  transmittance + reflectance + emissivity for each individual pane). The
+  per-pane model has 13+ optical fields whose combinations frequently make
+  EnergyPlus's SolveForWindowTemperatures FAIL TO CONVERGE (Fatal abort),
+  even when every field looks plausible individually. For "double pane" or
+  "triple pane" specs, use create_glazing_material with an equivalent
+  U-factor/SHGC for the whole assembly instead — do NOT assemble panes
+  yourself unless the spec literally lists per-pane optical data.
+
+CRITICAL — DEFAULT TO SimpleGlazingSystem FOR ALL WINDOWS:
+- For ANY window/glazing/fenestration material, your FIRST choice is
+  create_glazing_material (WindowMaterial:SimpleGlazingSystem). It needs
+  only U-factor, SHGC, and visible transmittance — three numbers that
+  almost never cause convergence problems.
+- Use create_glazing_layer_material (per-pane WindowMaterial:Glazing) ONLY
+  when the spec provides explicit per-pane optical data (e.g. "outer pane:
+  6mm clear glass, solar transmittance 0.77, emissivity 0.84"). If the
+  spec just says "double-glazed window U=1.8 SHGC=0.4", that is a
+  whole-window description — use create_glazing_material, NOT per-pane.
+- Reason: the per-pane model requires EnergyPlus to solve a coupled
+  heat-balance across layers, and LLM-generated optical parameters
+  frequently violate the solver's numerical constraints, causing a Fatal
+  "Convergence error in SolveForWindowTemperatures" that the agent cannot
+  recover from. The simplified model sidesteps this entirely.
 
 CRITICAL — GLASS MUST BE A WINDOWMATERIAL, NEVER AN OPAQUE MATERIAL:
 - Any material described as glass / glazing / window-pane / clear or tinted
   transparent layer (e.g. 'Float_Glass', 'Single_Glazing', 'Double_Pane')
-  MUST be created with create_glazing_material (whole-window) OR
-  create_glazing_layer_material (per-pane). NEVER use create_standard_material
-  or create_nomass_material for glass.
+  MUST be created with create_glazing_material (default) OR
+  create_glazing_layer_material (only with explicit per-pane data). NEVER
+  use create_standard_material or create_nomass_material for glass.
 - An opaque Material named 'Float_Glass' will make EnergyPlus abort with
   "FenestrationSurface has an opaque surface construction; it should have a
   window construction". A glazing construction REQUIRES a WindowMaterial layer.
@@ -49,14 +69,12 @@ CRITICAL — SimpleGlazingSystem IS A WHOLE-WINDOW MODEL, NOT A PANE:
   [SimpleGlazingSystem + AirGap + SimpleGlazingSystem] for a "double pane" —
   is INVALID: EnergyPlus has no per-pane optical data and aborts with a Fatal
   "Convergence error in SolveForWindowTemperatures" (NaN glass temperatures).
-- To build a REAL double/triple-pane window, use per-pane glass layers:
-    1. create_glazing_layer_material for each pane (e.g. 'Clear_Glass_3mm'),
-    2. create_airgap_material for the gap (e.g. 'Air_Gap_13mm'),
-    3. construction phase: create_construction(layers=['Clear_Glass_3mm',
-       'Air_Gap_13mm', 'Clear_Glass_3mm']).
-- Quick decision: if the spec gives a single U-factor/SHGC for the window,
-  use create_glazing_material (one layer). If it describes pane thicknesses
-  or a multi-pane makeup, use create_glazing_layer_material (layered).
+- For double/triple-pane windows WITHOUT explicit per-pane data, derive an
+  equivalent whole-window U-factor/SHGC and use create_glazing_material.
+  Typical values: single pane U≈5.8 SHGC≈0.78; double pane U≈1.8-2.8
+  SHGC≈0.4-0.6; triple pane U≈0.8-1.4 SHGC≈0.3-0.5.
+- ONLY use per-pane assembly (create_glazing_layer_material + airgap) when
+  the spec literally lists per-pane optical properties for each glass layer.
 
 Rules:
 - Material names must be unique and self-describing (e.g., 'Brick_100mm',

--- a/src/agent/nodes/surface.py
+++ b/src/agent/nodes/surface.py
@@ -47,6 +47,10 @@ Rules:
   report; do NOT invent names or create a surface with a broken reference.
 - >= 3 vertices per surface; four-vertex rectangles are most common.
 - Order counter-clockwise when viewed from OUTSIDE the zone.
+- Floor / Roof / Ceiling normals are AUTO-CORRECTED if reversed (the tool
+  flips vertex order so a Floor's outward normal points DOWN and a
+  Roof/Ceiling's points UP), so you do not need to worry about exact tilt,
+  but winding counter-clockwise from outside remains the convention.
 - No two vertices may coincide (tolerance 1e-10 m).
 - outside_boundary_condition:
     * Walls/roofs facing outdoors: 'Outdoors',

--- a/src/agent/tools/construction_tools.py
+++ b/src/agent/tools/construction_tools.py
@@ -28,6 +28,7 @@ _ALL_MATERIAL_TYPES = [
     "Material:NoMass",
     "Material:AirGap",
     "WindowMaterial:SimpleGlazingSystem",
+    "WindowMaterial:Glazing",
 ]
 
 # idfpy object-type strings for each construction variant. The plain

--- a/src/agent/tools/construction_tools.py
+++ b/src/agent/tools/construction_tools.py
@@ -7,6 +7,7 @@ from idfpy.models.thermal_zones import (
 )
 from langchain_core.tools import BaseTool, tool
 
+from idfpy.models.constructions import ConstructionAirBoundary
 from src.mcp.state import ConfigState
 
 _LAYER_FIELDS = [
@@ -29,6 +30,13 @@ _ALL_MATERIAL_TYPES = [
     "WindowMaterial:SimpleGlazingSystem",
 ]
 
+# idfpy object-type strings for each construction variant. The plain
+# `Construction` is a layered assembly; `Construction:AirBoundary` is a
+# layer-less open-air boundary used on interior subsurfaces (doors/windows
+# between zones) to connect them without a paired subsurface in the other
+# zone. Both are valid `construction_name` targets for surfaces/fenestrations.
+_ALL_CONSTRUCTION_TYPES = ["Construction", "Construction:AirBoundary"]
+
 
 def _ok(msg: str, data=None) -> str:
     return json.dumps({"success": True, "message": msg, "data": data})
@@ -40,6 +48,20 @@ def _err(msg: str, data=None) -> str:
 
 def _material_exists(idf, name: str) -> bool:
     return any(idf.has(t, name) for t in _ALL_MATERIAL_TYPES)
+
+
+def _find_construction(idf, name: str):
+    """Return the type and object for a layered or air-boundary construction."""
+    for construction_type in _ALL_CONSTRUCTION_TYPES:
+        obj = idf.get(construction_type, name)
+        if obj is not None:
+            return construction_type, obj
+    return None, None
+
+
+def _is_airboundary_construction(idf, name: str) -> bool:
+    """Return whether name identifies an air-boundary construction."""
+    return idf.has("Construction:AirBoundary", name)
 
 
 def make_construction_tools(config: ConfigState) -> list[BaseTool]:
@@ -56,6 +78,8 @@ def make_construction_tools(config: ConfigState) -> list[BaseTool]:
         """
         if idf.has("Construction", name):
             return _err(f"Construction '{name}' already exists.")
+        if idf.has("Construction:AirBoundary", name):
+            return _err(f"Construction '{name}' already exists (as an AirBoundary).")
         if not layers:
             return _err("Construction must have at least one layer.")
         if len(layers) > 10:
@@ -80,22 +104,81 @@ def make_construction_tools(config: ConfigState) -> list[BaseTool]:
             return _err(f"Error creating construction '{name}': {e}")
 
     @tool
+    def create_airboundary_construction(
+        name: str,
+        air_exchange_method: str = "None",
+        simple_mixing_air_changes_per_hour: float | None = None,
+        simple_mixing_schedule_name: str | None = None,
+    ) -> str:
+        """Create a Construction:AirBoundary — a layer-less open-air boundary.
+
+        Used on INTERIOR subsurfaces (doors/windows/glass-doors hosted on a
+        zone-separating wall whose Outside Boundary Condition is 'Surface') to
+        model an open passage between zones. It has no material layers and
+        does NOT require a paired subsurface in the adjacent zone, unlike a
+        regular interior construction. Assign it as the construction_name of
+        interior doors/windows.
+
+        Args:
+            name: Unique construction name (e.g., 'Interior_Door_Open').
+            air_exchange_method: 'None' (radiant/daylighting only, default) or
+                                 'SimpleMixing' (adds an air-mixing rate).
+            simple_mixing_air_changes_per_hour: Required when method is
+                'SimpleMixing'; air changes per hour based on the smaller
+                zone's volume. Ignored otherwise.
+            simple_mixing_schedule_name: Optional Schedule:Compact name for the
+                SimpleMixing rate. Only valid with method 'SimpleMixing'.
+        """
+        if idf.has("Construction:AirBoundary", name):
+            return _err(f"Construction:AirBoundary '{name}' already exists.")
+        if idf.has("Construction", name):
+            return _err(f"Construction '{name}' already exists (as a layered Construction).")
+        try:
+            kwargs: dict = {"name": name, "air_exchange_method": air_exchange_method}
+            if air_exchange_method == "SimpleMixing":
+                if simple_mixing_air_changes_per_hour is None:
+                    return _err(
+                        "simple_mixing_air_changes_per_hour is required when "
+                        "air_exchange_method is 'SimpleMixing'."
+                    )
+                kwargs["simple_mixing_air_changes_per_hour"] = simple_mixing_air_changes_per_hour
+                if simple_mixing_schedule_name is not None:
+                    kwargs["simple_mixing_schedule_name"] = simple_mixing_schedule_name
+            idf.add(ConstructionAirBoundary(**kwargs))
+            return _ok(
+                f"Construction:AirBoundary '{name}' created successfully.",
+                idf.get("Construction:AirBoundary", name).model_dump(),
+            )
+        except Exception as e:
+            return _err(f"Error creating Construction:AirBoundary '{name}': {e}")
+
+    @tool
     def list_constructions() -> str:
-        """List all constructions."""
-        items = [c.model_dump() for c in idf.all_of_type(Construction).values()]
+        """List all constructions (layered Construction + Construction:AirBoundary)."""
+        items = []
+        for t in _ALL_CONSTRUCTION_TYPES:
+            for obj in idf.all_of_type(t).values():
+                items.append({"type": t, **obj.model_dump()})
         return _ok(f"Listed {len(items)} constructions.", items)
 
     @tool
     def get_construction(name: str) -> str:
-        """Read a construction by name."""
-        obj = idf.get(Construction, name)
+        """Read a construction by name (layered or AirBoundary)."""
+        const_type, obj = _find_construction(idf, name)
         if obj is None:
             return _err(f"Construction '{name}' not found.")
-        return _ok(f"Construction '{name}' read successfully.", obj.model_dump())
+        return _ok(
+            f"Construction '{name}' read successfully.",
+            {"type": const_type, **obj.model_dump()},
+        )
 
     @tool
     def update_construction(name: str, layers: list[str]) -> str:
-        """Replace the entire layer sequence of an existing construction.
+        """Replace the entire layer sequence of an existing layered Construction.
+
+        Only applies to layered `Construction` objects — NOT to
+        `Construction:AirBoundary` (which has no layers). To change an
+        AirBoundary, delete and recreate it.
 
         Args:
             name: Existing construction name.
@@ -104,6 +187,12 @@ def make_construction_tools(config: ConfigState) -> list[BaseTool]:
         """
         obj = idf.get("Construction", name)
         if obj is None:
+            # Distinguish "not found" from "is an AirBoundary (wrong tool)".
+            if idf.has("Construction:AirBoundary", name):
+                return _err(
+                    f"'{name}' is a Construction:AirBoundary and has no layers; "
+                    f"use delete_construction + create_airboundary_construction."
+                )
             return _err(f"Construction '{name}' not found.")
         if not layers or len(layers) > 10:
             return _err("Construction must have 1-10 layers.")
@@ -126,8 +215,12 @@ def make_construction_tools(config: ConfigState) -> list[BaseTool]:
 
     @tool
     def delete_construction(name: str) -> str:
-        """Delete a construction. Fails if referenced by surfaces/fenestration."""
-        if not idf.has("Construction", name):
+        """Delete a construction (layered or AirBoundary).
+
+        Fails if referenced by surfaces/fenestration.
+        """
+        const_type, _obj = _find_construction(idf, name)
+        if const_type is None:
             return _err(f"Construction '{name}' not found.")
         refs = []
         for s in idf.all_of_type(BuildingSurfaceDetailed).values():
@@ -141,7 +234,7 @@ def make_construction_tools(config: ConfigState) -> list[BaseTool]:
                 f"Construction '{name}' is referenced by other components.",
                 {"references": refs},
             )
-        idf.remove("Construction", name)
+        idf.remove(const_type, name)
         return _ok(f"Construction '{name}' deleted successfully.")
 
     @tool
@@ -155,6 +248,7 @@ def make_construction_tools(config: ConfigState) -> list[BaseTool]:
 
     return [
         create_construction,
+        create_airboundary_construction,
         list_constructions,
         get_construction,
         update_construction,

--- a/src/agent/tools/fenestration_tools.py
+++ b/src/agent/tools/fenestration_tools.py
@@ -289,7 +289,15 @@ def make_fenestration_tools(config: ConfigState) -> list[BaseTool]:
         # it should have a window construction". Back-hop to material so it
         # creates the WindowMaterial:SimpleGlazingSystem, after which
         # construction can rebuild the window construction with it.
-        if surface_type in _GLAZING_SURFACE_TYPES and not _is_glazing_construction(idf, construction_name):
+        # EXCEPTION: an AirBoundary construction is the legitimate choice for
+        # INTERIOR windows/glass-doors (open-air passage between zones); it
+        # has no WindowMaterial and must NOT be flagged here. The dedicated
+        # interzone check below governs AirBoundary usage.
+        if (
+            surface_type in _GLAZING_SURFACE_TYPES
+            and not _is_glazing_construction(idf, construction_name)
+            and not _is_airboundary_construction(idf, construction_name)
+        ):
             return _err(
                 f"Construction '{construction_name}' is opaque (no WindowMaterial "
                 f"layer) and cannot be used for {surface_type} '{name}'. "
@@ -420,7 +428,9 @@ def make_fenestration_tools(config: ConfigState) -> list[BaseTool]:
         # EFFECTIVE surface_type (new value if provided, else the object's
         # existing one) and the EFFECTIVE construction (new if provided, else
         # the object's existing one) so reparenting a window onto a new
-        # construction is validated the same way as a fresh create.
+        # construction is validated the same way as a fresh create. An
+        # AirBoundary construction is exempt (it is the valid choice for an
+        # interior window/glass-door — see create_fenestration for rationale).
         if construction_name is not None:
             effective_type = surface_type or obj.surface_type
             effective_const = construction_name
@@ -431,6 +441,7 @@ def make_fenestration_tools(config: ConfigState) -> list[BaseTool]:
             effective_type in _GLAZING_SURFACE_TYPES
             and effective_const
             and not _is_glazing_construction(idf, effective_const)
+            and not _is_airboundary_construction(idf, effective_const)
         ):
             return _err(
                 f"Construction '{effective_const}' is opaque (no WindowMaterial "

--- a/src/agent/tools/fenestration_tools.py
+++ b/src/agent/tools/fenestration_tools.py
@@ -1,4 +1,5 @@
 import json
+import math
 
 from idfpy.models.constructions import Construction
 from idfpy.models.thermal_zones import (
@@ -16,6 +17,165 @@ def _ok(msg: str, data=None) -> str:
 
 def _err(msg: str, data=None) -> str:
     return json.dumps({"success": False, "message": msg, "data": data})
+
+
+# Tolerance for the post-flip re-check in _align_window_to_wall. A backward
+# window (dot < 0) is FIXED by the single allowed flip above, not rejected
+# here — a coplanar window's dot sign simply inverts under reversal, so
+# flipping once always turns a backward coplanar window positive. This check
+# only catches the rare case where, after flipping, the dot is still at or
+# below zero: geometry that slipped past the earlier coplanarity guard
+# (Check 1) and zero-area guard. It is a last-resort safety net, not the
+# primary defense.
+_NORMAL_DOT_TOLERANCE = 0.01
+
+# Maximum allowed distance (m) from any window vertex to the parent wall's
+# plane. A window that passes the normal-direction check but has vertices
+# off the wall plane is a warped/non-coplanar polygon — Newell's normal can
+# still align with the wall by chance, so we additionally require every
+# vertex to lie (near) on the plane. 1 cm tolerates float rounding.
+_COPLANARITY_TOLERANCE = 0.01
+
+
+def _surface_normal(vertices: list[tuple[float, float, float]]) -> tuple[float, float, float]:
+    """Unit outward normal of a polygon via Newell's method.
+
+    Robust to non-strictly-planar quads (sums contributions per edge), so it
+    matches EnergyPlus' own surface-normal computation.
+    """
+    nx = ny = nz = 0.0
+    n = len(vertices)
+    for i in range(n):
+        ax, ay, az = vertices[i]
+        bx, by, bz = vertices[(i + 1) % n]
+        nx += (ay - by) * (az + bz)
+        ny += (az - bz) * (ax + bx)
+        nz += (ax - bx) * (ay + by)
+    length = math.sqrt(nx * nx + ny * ny + nz * nz)
+    if length == 0.0:
+        return (0.0, 0.0, 0.0)  # degenerate (collinear / duplicate) vertices
+    return (nx / length, ny / length, nz / length)
+
+
+def _max_distance_to_plane(
+    points: list[tuple[float, float, float]],
+    plane_normal: tuple[float, float, float],
+    plane_point: tuple[float, float, float],
+) -> float:
+    """Largest absolute distance from any point to the plane."""
+    a, b, c = plane_normal
+    px, py, pz = plane_point
+    worst = 0.0
+    for x, y, z in points:
+        d = abs((x - px) * a + (y - py) * b + (z - pz) * c)
+        if d > worst:
+            worst = d
+    return worst
+
+
+def _wall_vertices(wall_obj) -> list[tuple[float, float, float]]:
+    """Extract (x, y, z) tuples from a BuildingSurface:Detailed object.
+
+    idfpy stores wall geometry as a nested ``vertices`` list (each item has
+    ``vertex_{x,y,z}_coordinate``), which is a different shape from
+    FenestrationSurface's flat ``vertex_{i}_{x,y,z}_coordinate`` attributes.
+    Read the nested list first, fall back to the flat attributes defensively.
+    """
+    nested = getattr(wall_obj, "vertices", None)
+    if nested:
+        pts = []
+        for item in nested:
+            x = getattr(item, "vertex_x_coordinate", None)
+            y = getattr(item, "vertex_y_coordinate", None)
+            z = getattr(item, "vertex_z_coordinate", None)
+            if x is not None and y is not None and z is not None:
+                pts.append((float(x), float(y), float(z)))
+        if len(pts) >= 3:
+            return pts
+
+    # Fallback: flat vertex_{i}_{axis}_coordinate attributes.
+    pts: dict[int, dict[str, float]] = {}
+    for i in range(1, 5):
+        for axis in ("x", "y", "z"):
+            val = getattr(wall_obj, f"vertex_{i}_{axis}_coordinate", None)
+            if val is None:
+                val = getattr(wall_obj, f"vertex_{axis}_coordinate_{i}", None)
+            if val is not None:
+                pts.setdefault(i, {})[axis] = float(val)
+    return [(pts[i]["x"], pts[i]["y"], pts[i]["z"]) for i in sorted(pts)]
+
+
+def _align_window_to_wall(
+    vertices: list[dict[str, float]], wall_obj
+) -> tuple[list[dict[str, float]] | None, str | None]:
+    """Ensure the window lies on the parent wall and faces the same way.
+
+    Two independent checks, because normal direction alone cannot tell a
+    warped polygon from a flat one (Newell's normal can still align with
+    the wall by chance for a non-coplanar quad):
+
+      1. Coplanarity — every window vertex must lie within
+         ``_COPLANARITY_TOLERANCE`` of the wall plane. Rejects windows that
+         are tilted off the wall or not flat.
+      2. Normal direction — ``dot(window_normal, wall_normal)`` must be
+         positive after at most one winding flip. dot < 0 reverses the
+         vertex order (the single allowed flip); a coplanar window is always
+         fixed by that one flip. If the re-check is still at/below tolerance
+         the geometry is degenerate (collinear/duplicate → zero-area normal).
+
+    Returns (aligned_vertices, None) on success, or (None, error_message)
+    when the window cannot be made consistent — callers must NOT store it.
+    """
+    wall_pts = _wall_vertices(wall_obj)
+    if len(wall_pts) < 3:
+        return None, "Parent surface has fewer than 3 vertices; cannot verify window orientation."
+
+    win_pts = [(float(v["X"]), float(v["Y"]), float(v["Z"])) for v in vertices]
+    wall_n = _surface_normal(wall_pts)
+    if wall_n == (0.0, 0.0, 0.0):
+        return None, "Parent surface has degenerate (zero-area) geometry; cannot verify window orientation."
+
+    # Plane anchor = centroid of the wall vertices. Newell's normal is the
+    # normal of the best-fit plane, and that plane passes through the
+    # centroid, so the centroid is a more accurate on-plane reference point
+    # than any single vertex (which may sit off the best-fit plane for a
+    # slightly non-planar wall polygon).
+    m = len(wall_pts)
+    anchor = (
+        sum(p[0] for p in wall_pts) / m,
+        sum(p[1] for p in wall_pts) / m,
+        sum(p[2] for p in wall_pts) / m,
+    )
+
+    # Check 1: coplanarity (vertex-to-plane distance).
+    max_dist = _max_distance_to_plane(win_pts, wall_n, anchor)
+    if max_dist > _COPLANARITY_TOLERANCE:
+        return None, (
+            "Window is not coplanar with the parent surface "
+            "(max vertex-to-plane distance=%.4fm, limit=%.4fm). Every window "
+            "vertex must share the wall's plane coordinate." % (max_dist, _COPLANARITY_TOLERANCE)
+        )
+
+    # Check 2: normal direction (flip once if backward, then re-verify).
+    win_n = _surface_normal(win_pts)
+    if win_n == (0.0, 0.0, 0.0):
+        return None, "Window has degenerate (zero-area) geometry — vertices are collinear or duplicated."
+
+    dot = win_n[0] * wall_n[0] + win_n[1] * wall_n[1] + win_n[2] * wall_n[2]
+    if dot < 0:
+        win_pts.reverse()  # single allowed flip; CCW <-> CW
+        # Recompute normal after reversal (sign flips for a coplanar polygon).
+        win_n = _surface_normal(win_pts)
+        dot = win_n[0] * wall_n[0] + win_n[1] * wall_n[1] + win_n[2] * wall_n[2]
+
+    if dot <= _NORMAL_DOT_TOLERANCE:
+        return None, (
+            "Window normal is still not consistent with the parent surface "
+            "after winding correction (dot=%.3f). Re-check the window geometry." % dot
+        )
+
+    aligned = [{"X": x, "Y": y, "Z": z} for (x, y, z) in win_pts]
+    return aligned, None
 
 
 def make_fenestration_tools(config: ConfigState) -> list[BaseTool]:
@@ -39,8 +199,10 @@ def make_fenestration_tools(config: ConfigState) -> list[BaseTool]:
             building_surface_name: Existing parent Surface name.
             vertices: List of vertex dicts in meters. Each vertex is
                       `{"X": float, "Y": float, "Z": float}`. >= 3 points,
-                      counter-clockwise from the outside, MUST lie on the
-                      parent surface plane (coplanar).
+                      and MUST be coplanar with the parent surface (share the
+                      wall's plane coordinate). Winding direction does not
+                      matter — the tool auto-aligns the window's outward
+                      normal to the parent wall's.
                       Example 1.5x1.2m window centered on a south wall at
                       sill 0.8m (wall at y=0, spans x=0..5):
                         [{"X": 1.75, "Y": 0.0, "Z": 0.8},
@@ -62,6 +224,17 @@ def make_fenestration_tools(config: ConfigState) -> list[BaseTool]:
                 {"missing_ref": "BuildingSurface:Detailed", "missing_name": building_surface_name},
             )
         try:
+            # Auto-correct window winding to match the parent wall's outward
+            # normal. Reject (without storing) if the window cannot be made
+            # consistent — i.e. it is not coplanar with the wall.
+            wall_obj = idf.get("BuildingSurface:Detailed", building_surface_name)
+            aligned, align_err = _align_window_to_wall(vertices, wall_obj)
+            if align_err is not None:
+                return _err(
+                    f"Cannot create fenestration '{name}': {align_err}",
+                    {"building_surface_name": building_surface_name},
+                )
+            vertices = aligned
             kwargs: dict = {
                 "name": name,
                 "surface_type": surface_type,
@@ -120,8 +293,17 @@ def make_fenestration_tools(config: ConfigState) -> list[BaseTool]:
             building_surface_name: New parent Surface name (must exist).
             surface_type: Window / Door / GlassDoor.
             multiplier: Number of identical copies (>= 1).
-            vertices: New full vertex list ({"X","Y","Z"} dicts), >= 3 points,
-                      coplanar with the parent surface.
+            vertices: New full vertex list ({"X","Y","Z"} dicts), 3-4 points,
+                      coplanar with the parent surface. Winding direction is
+                      auto-aligned to the parent wall's outward normal.
+
+        Note:
+            Reparenting (passing ``building_surface_name`` without
+            ``vertices``) moves the window to the new wall but does NOT
+            re-derive its geometry — the existing vertices are kept as-is,
+            which may no longer be coplanar with the new parent. To move a
+            window to a different wall correctly, pass the new parent AND a
+            fresh ``vertices`` list on that wall's plane.
         """
         obj = idf.get("FenestrationSurface:Detailed", name)
         if obj is None:
@@ -137,6 +319,28 @@ def make_fenestration_tools(config: ConfigState) -> list[BaseTool]:
                 {"missing_ref": "BuildingSurface:Detailed", "missing_name": building_surface_name},
             )
         try:
+            # Resolve the effective parent (new if provided, else current) and
+            # auto-correct the new window winding BEFORE mutating any field,
+            # so a rejected geometry leaves the existing object untouched.
+            aligned_vertices: list[dict[str, float]] | None = None
+            if vertices is not None:
+                if len(vertices) < 3 or len(vertices) > 4:
+                    return _err("Fenestration needs 3 or 4 vertices.")
+                parent_name = building_surface_name or obj.building_surface_name
+                wall_obj = idf.get("BuildingSurface:Detailed", parent_name)
+                if wall_obj is None:
+                    return _err(
+                        f"Parent surface '{parent_name}' not found.",
+                        {"missing_ref": "BuildingSurface:Detailed", "missing_name": parent_name},
+                    )
+                aligned, align_err = _align_window_to_wall(vertices, wall_obj)
+                if align_err is not None:
+                    return _err(
+                        f"Cannot update fenestration '{name}': {align_err}",
+                        {"building_surface_name": parent_name},
+                    )
+                aligned_vertices = aligned
+
             if construction_name is not None:
                 obj.construction_name = construction_name
             if building_surface_name is not None:
@@ -145,17 +349,20 @@ def make_fenestration_tools(config: ConfigState) -> list[BaseTool]:
                 obj.surface_type = surface_type
             if multiplier is not None:
                 obj.multiplier = float(multiplier)
-            if vertices is not None:
-                if len(vertices) < 3:
-                    return _err("Fenestration needs >= 3 vertices.")
-                # Clear any existing vertex fields (up to 4), then set new ones
-                for i in range(1, 5):
-                    for axis in ("x", "y", "z"):
-                        setattr(obj, f"vertex_{i}_{axis}_coordinate", None)
+            if aligned_vertices is not None:
+                vertices = aligned_vertices
+                # Overwrite in place; do NOT blank fields first — vertex_1..3
+                # are required `float` fields and reject None, so a
+                # clear-then-set sequence raises ValidationError before the
+                # new values are ever written (see thermal_zones.py:656-664).
+                # vertex_4 is the only vertex that allows None.
                 for i, v in enumerate(vertices, start=1):
                     setattr(obj, f"vertex_{i}_x_coordinate", float(v["X"]))
                     setattr(obj, f"vertex_{i}_y_coordinate", float(v["Y"]))
                     setattr(obj, f"vertex_{i}_z_coordinate", float(v["Z"]))
+                if len(vertices) < 4:
+                    for axis in ("x", "y", "z"):
+                        setattr(obj, f"vertex_4_{axis}_coordinate", None)
                 obj.number_of_vertices = len(vertices)
             return _ok(f"Fenestration '{name}' updated successfully.",
                        obj.model_dump())

--- a/src/agent/tools/fenestration_tools.py
+++ b/src/agent/tools/fenestration_tools.py
@@ -109,6 +109,35 @@ def _is_glazing_construction(idf, construction_name: str) -> bool:
     return False
 
 
+def _is_airboundary_construction(idf, construction_name: str) -> bool:
+    """True if *construction_name* is a Construction:AirBoundary (open-air)."""
+    return idf.has("Construction:AirBoundary", construction_name)
+
+
+def _construction_exists(idf, name: str) -> bool:
+    """True if *name* is a layered Construction or a Construction:AirBoundary."""
+    return idf.has("Construction", name) or idf.has("Construction:AirBoundary", name)
+
+
+def _parent_boundary_condition(idf, building_surface_name: str) -> str | None:
+    """Outside boundary condition of a fenestration's parent base surface.
+
+    Returns None if the parent surface does not exist. When the value is
+    'Surface', the parent is a zone-separating (interzone) wall, which
+    triggers EnergyPlus' rule that subsurfaces must also name an adjacent
+    surface — the AirBoundary workaround bypasses that requirement.
+    """
+    parent = idf.get("BuildingSurface:Detailed", building_surface_name)
+    if parent is None:
+        return None
+    return getattr(parent, "outside_boundary_condition", None)
+
+
+def _parent_is_interzone(idf, building_surface_name: str) -> bool:
+    """True if the parent base surface separates two zones (Surface boundary)."""
+    return _parent_boundary_condition(idf, building_surface_name) == "Surface"
+
+
 def _wall_vertices(wall_obj) -> list[tuple[float, float, float]]:
     """Extract (x, y, z) tuples from a BuildingSurface:Detailed object.
 
@@ -249,7 +278,7 @@ def make_fenestration_tools(config: ConfigState) -> list[BaseTool]:
         """
         if idf.has("FenestrationSurface:Detailed", name):
             return _err(f"Fenestration '{name}' already exists.")
-        if not idf.has("Construction", construction_name):
+        if not _construction_exists(idf, construction_name):
             return _err(
                 f"Construction '{construction_name}' not found. Create it in the construction phase first.",
                 {"missing_ref": "Construction", "missing_name": construction_name},
@@ -275,6 +304,27 @@ def make_fenestration_tools(config: ConfigState) -> list[BaseTool]:
             return _err(
                 f"Parent surface '{building_surface_name}' not found.",
                 {"missing_ref": "BuildingSurface:Detailed", "missing_name": building_surface_name},
+            )
+        # Interior-subsurface rule: when the parent base surface separates two
+        # zones (Outside Boundary Condition = 'Surface'), a subsurface that is
+        # NOT an AirBoundary construction leaves its own Outside Boundary
+        # Condition Object blank, which EnergyPlus rejects with "invalid blank
+        # Outside Boundary Condition Object". The agent does not pair adjacent-
+        # zone subsurfaces, so interior doors/windows MUST use a
+        # Construction:AirBoundary (open-air) construction. Back-hop to
+        # construction so it creates one.
+        if (
+            _parent_is_interzone(idf, building_surface_name)
+            and not _is_airboundary_construction(idf, construction_name)
+        ):
+            return _err(
+                f"Parent surface '{building_surface_name}' is an interior "
+                f"(zone-separating) wall. {surface_type} '{name}' must use a "
+                f"Construction:AirBoundary (create via "
+                f"create_airboundary_construction) so it models an open "
+                f"passage; '{construction_name}' is a regular layered "
+                f"construction and would leave its boundary object blank.",
+                {"missing_ref": "Construction", "missing_name": "Construction:AirBoundary"},
             )
         try:
             # Auto-correct window winding to match the parent wall's outward
@@ -361,7 +411,7 @@ def make_fenestration_tools(config: ConfigState) -> list[BaseTool]:
         obj = idf.get("FenestrationSurface:Detailed", name)
         if obj is None:
             return _err(f"Fenestration '{name}' not found.")
-        if construction_name is not None and not idf.has("Construction", construction_name):
+        if construction_name is not None and not _construction_exists(idf, construction_name):
             return _err(
                 f"Construction '{construction_name}' not found.",
                 {"missing_ref": "Construction", "missing_name": construction_name},
@@ -396,6 +446,27 @@ def make_fenestration_tools(config: ConfigState) -> list[BaseTool]:
             return _err(
                 f"Parent surface '{building_surface_name}' not found.",
                 {"missing_ref": "BuildingSurface:Detailed", "missing_name": building_surface_name},
+            )
+        # Interior-subsurface rule (mirrors create_fenestration). Uses the
+        # EFFECTIVE parent (new if provided, else current) and EFFECTIVE
+        # construction so reparenting / re-assigning is validated like a fresh
+        # create. An interior (Surface-boundary) parent requires the subsurface
+        # to use a Construction:AirBoundary; a regular layered construction
+        # would leave the boundary object blank and abort EnergyPlus.
+        effective_parent = building_surface_name or obj.building_surface_name
+        effective_const_for_interzone = construction_name or obj.construction_name
+        if (
+            _parent_is_interzone(idf, effective_parent)
+            and effective_const_for_interzone
+            and not _is_airboundary_construction(idf, effective_const_for_interzone)
+        ):
+            return _err(
+                f"Parent surface '{effective_parent}' is an interior "
+                f"(zone-separating) wall. '{name}' must use a "
+                f"Construction:AirBoundary (create via "
+                f"create_airboundary_construction); '{effective_const_for_interzone}' "
+                f"is a regular layered construction.",
+                {"missing_ref": "Construction", "missing_name": "Construction:AirBoundary"},
             )
         try:
             # Resolve the effective parent (new if provided, else current) and

--- a/src/agent/tools/fenestration_tools.py
+++ b/src/agent/tools/fenestration_tools.py
@@ -73,6 +73,42 @@ def _max_distance_to_plane(
     return worst
 
 
+# Fenestration surface_types that MUST be backed by a glazing (window)
+# construction — i.e. one whose layer list contains a WindowMaterial. A
+# plain Door is the only opaque-allowed type; Window / GlassDoor /
+# TubularDaylight* all need glass. EnergyPlus aborts with a Severe error
+# ("has an opaque surface construction; it should have a window
+# construction") if this is violated, so we catch it at tool-call time
+# and back-hop to material to create the missing WindowMaterial.
+_GLAZING_SURFACE_TYPES = frozenset(
+    {"Window", "GlassDoor", "TubularDaylightDiffuser", "TubularDaylightDome"}
+)
+
+# Construction layer fields, mirroring construction_tools._LAYER_FIELDS.
+_CONSTRUCTION_LAYER_FIELDS = (
+    "outside_layer",
+    "layer_2", "layer_3", "layer_4", "layer_5",
+    "layer_6", "layer_7", "layer_8", "layer_9", "layer_10",
+)
+
+
+def _is_glazing_construction(idf, construction_name: str) -> bool:
+    """True if *construction_name* has at least one WindowMaterial layer.
+
+    EnergyPlus classifies a construction as a "window construction" when any
+    of its layers is a WindowMaterial:* object (here, the only window
+    material variant the agent creates is WindowMaterial:SimpleGlazingSystem).
+    """
+    const = idf.get("Construction", construction_name)
+    if const is None:
+        return False
+    for field in _CONSTRUCTION_LAYER_FIELDS:
+        layer = getattr(const, field, None)
+        if layer and idf.has("WindowMaterial:SimpleGlazingSystem", layer):
+            return True
+    return False
+
+
 def _wall_vertices(wall_obj) -> list[tuple[float, float, float]]:
     """Extract (x, y, z) tuples from a BuildingSurface:Detailed object.
 
@@ -218,6 +254,23 @@ def make_fenestration_tools(config: ConfigState) -> list[BaseTool]:
                 f"Construction '{construction_name}' not found. Create it in the construction phase first.",
                 {"missing_ref": "Construction", "missing_name": construction_name},
             )
+        # A window/glass-door/skylight MUST reference a glazing construction
+        # (one whose layers include a WindowMaterial). An opaque construction
+        # makes EnergyPlus abort with "has an opaque surface construction;
+        # it should have a window construction". Back-hop to material so it
+        # creates the WindowMaterial:SimpleGlazingSystem, after which
+        # construction can rebuild the window construction with it.
+        if surface_type in _GLAZING_SURFACE_TYPES and not _is_glazing_construction(idf, construction_name):
+            return _err(
+                f"Construction '{construction_name}' is opaque (no WindowMaterial "
+                f"layer) and cannot be used for {surface_type} '{name}'. "
+                f"Create a WindowMaterial:SimpleGlazingSystem glazing material "
+                f"and rebuild the construction to use it.",
+                {
+                    "missing_ref": "WindowMaterial:SimpleGlazingSystem",
+                    "missing_name": construction_name,
+                },
+            )
         if not idf.has("BuildingSurface:Detailed", building_surface_name):
             return _err(
                 f"Parent surface '{building_surface_name}' not found.",
@@ -312,6 +365,32 @@ def make_fenestration_tools(config: ConfigState) -> list[BaseTool]:
             return _err(
                 f"Construction '{construction_name}' not found.",
                 {"missing_ref": "Construction", "missing_name": construction_name},
+            )
+        # Glazing-construction check (mirrors create_fenestration). Uses the
+        # EFFECTIVE surface_type (new value if provided, else the object's
+        # existing one) and the EFFECTIVE construction (new if provided, else
+        # the object's existing one) so reparenting a window onto a new
+        # construction is validated the same way as a fresh create.
+        if construction_name is not None:
+            effective_type = surface_type or obj.surface_type
+            effective_const = construction_name
+        else:
+            effective_type = surface_type or obj.surface_type
+            effective_const = obj.construction_name
+        if (
+            effective_type in _GLAZING_SURFACE_TYPES
+            and effective_const
+            and not _is_glazing_construction(idf, effective_const)
+        ):
+            return _err(
+                f"Construction '{effective_const}' is opaque (no WindowMaterial "
+                f"layer) and cannot be used for {effective_type} '{name}'. "
+                f"Create a WindowMaterial:SimpleGlazingSystem glazing material "
+                f"and rebuild the construction to use it.",
+                {
+                    "missing_ref": "WindowMaterial:SimpleGlazingSystem",
+                    "missing_name": effective_const,
+                },
             )
         if building_surface_name is not None and not idf.has("BuildingSurface:Detailed", building_surface_name):
             return _err(

--- a/src/agent/tools/fenestration_tools.py
+++ b/src/agent/tools/fenestration_tools.py
@@ -1,5 +1,4 @@
 import json
-import math
 
 from idfpy.models.constructions import Construction
 from idfpy.models.thermal_zones import (
@@ -8,7 +7,15 @@ from idfpy.models.thermal_zones import (
 )
 from langchain_core.tools import BaseTool, tool
 
+from src.mcp.geometry import surface_normal, surface_vertices
 from src.mcp.state import ConfigState
+
+# Aliases preserve the historical private names used throughout this module
+# (call sites below unchanged). The implementations now live in the neutral
+# ``src.mcp.geometry`` module so they can be shared with ``src.mcp.state``
+# without a circular import (this module already imports ``src.mcp.state``).
+_surface_normal = surface_normal
+_wall_vertices = surface_vertices
 
 
 def _ok(msg: str, data=None) -> str:
@@ -35,26 +42,6 @@ _NORMAL_DOT_TOLERANCE = 0.01
 # still align with the wall by chance, so we additionally require every
 # vertex to lie (near) on the plane. 1 cm tolerates float rounding.
 _COPLANARITY_TOLERANCE = 0.01
-
-
-def _surface_normal(vertices: list[tuple[float, float, float]]) -> tuple[float, float, float]:
-    """Unit outward normal of a polygon via Newell's method.
-
-    Robust to non-strictly-planar quads (sums contributions per edge), so it
-    matches EnergyPlus' own surface-normal computation.
-    """
-    nx = ny = nz = 0.0
-    n = len(vertices)
-    for i in range(n):
-        ax, ay, az = vertices[i]
-        bx, by, bz = vertices[(i + 1) % n]
-        nx += (ay - by) * (az + bz)
-        ny += (az - bz) * (ax + bx)
-        nz += (ax - bx) * (ay + by)
-    length = math.sqrt(nx * nx + ny * ny + nz * nz)
-    if length == 0.0:
-        return (0.0, 0.0, 0.0)  # degenerate (collinear / duplicate) vertices
-    return (nx / length, ny / length, nz / length)
 
 
 def _max_distance_to_plane(
@@ -136,38 +123,6 @@ def _parent_boundary_condition(idf, building_surface_name: str) -> str | None:
 def _parent_is_interzone(idf, building_surface_name: str) -> bool:
     """True if the parent base surface separates two zones (Surface boundary)."""
     return _parent_boundary_condition(idf, building_surface_name) == "Surface"
-
-
-def _wall_vertices(wall_obj) -> list[tuple[float, float, float]]:
-    """Extract (x, y, z) tuples from a BuildingSurface:Detailed object.
-
-    idfpy stores wall geometry as a nested ``vertices`` list (each item has
-    ``vertex_{x,y,z}_coordinate``), which is a different shape from
-    FenestrationSurface's flat ``vertex_{i}_{x,y,z}_coordinate`` attributes.
-    Read the nested list first, fall back to the flat attributes defensively.
-    """
-    nested = getattr(wall_obj, "vertices", None)
-    if nested:
-        pts = []
-        for item in nested:
-            x = getattr(item, "vertex_x_coordinate", None)
-            y = getattr(item, "vertex_y_coordinate", None)
-            z = getattr(item, "vertex_z_coordinate", None)
-            if x is not None and y is not None and z is not None:
-                pts.append((float(x), float(y), float(z)))
-        if len(pts) >= 3:
-            return pts
-
-    # Fallback: flat vertex_{i}_{axis}_coordinate attributes.
-    pts: dict[int, dict[str, float]] = {}
-    for i in range(1, 5):
-        for axis in ("x", "y", "z"):
-            val = getattr(wall_obj, f"vertex_{i}_{axis}_coordinate", None)
-            if val is None:
-                val = getattr(wall_obj, f"vertex_{axis}_coordinate_{i}", None)
-            if val is not None:
-                pts.setdefault(i, {})[axis] = float(val)
-    return [(pts[i]["x"], pts[i]["y"], pts[i]["z"]) for i in sorted(pts)]
 
 
 def _align_window_to_wall(

--- a/src/agent/tools/fenestration_tools.py
+++ b/src/agent/tools/fenestration_tools.py
@@ -83,15 +83,34 @@ def _is_glazing_construction(idf, construction_name: str) -> bool:
     """True if *construction_name* has at least one WindowMaterial layer.
 
     EnergyPlus classifies a construction as a "window construction" when any
-    of its layers is a WindowMaterial:* object (here, the only window
-    material variant the agent creates is WindowMaterial:SimpleGlazingSystem).
+    of its layers is a WindowMaterial:* object. The agent creates TWO
+    window-material variants, both of which legally qualify a construction
+    as glazing:
+
+    - WindowMaterial:SimpleGlazingSystem — a simplified whole-window model
+      (U/SHGC/VT only), created via create_glazing_material. Must be the
+      sole layer.
+    - WindowMaterial:Glazing — a true per-pane glass layer (thickness +
+      per-pane optical data), created via create_glazing_layer_material.
+      Composed with Material:AirGap in multi-pane assemblies.
+
+    Checking only SimpleGlazingSystem (the original implementation) wrongly
+    rejects a valid multi-pane window built from WindowMaterial:Glazing
+    layers as "opaque", which silently drops every fenestration — the
+    window is never created because create_fenestration refuses an "opaque"
+    construction.
     """
     const = idf.get("Construction", construction_name)
     if const is None:
         return False
     for field in _CONSTRUCTION_LAYER_FIELDS:
         layer = getattr(const, field, None)
-        if layer and idf.has("WindowMaterial:SimpleGlazingSystem", layer):
+        if not layer:
+            continue
+        if (
+            idf.has("WindowMaterial:SimpleGlazingSystem", layer)
+            or idf.has("WindowMaterial:Glazing", layer)
+        ):
             return True
     return False
 

--- a/src/agent/tools/material_tools.py
+++ b/src/agent/tools/material_tools.py
@@ -135,7 +135,17 @@ def make_material_tools(config: ConfigState) -> list[BaseTool]:
         solar_heat_gain_coefficient: float,
         visible_transmittance: float | None = None,
     ) -> str:
-        """Create a Glazing material (simplified window).
+        """Create a Glazing material (WindowMaterial:SimpleGlazingSystem).
+
+        THIS IS THE PREFERRED AND DEFAULT WAY TO MODEL WINDOWS. Use it for
+        all windows, including "double pane", "triple pane", "low-e", and
+        "clear glass" specs — just provide the whole-window equivalent
+        U-factor / SHGC / VT. Typical values:
+          single pane:  U~5.8  SHGC~0.78
+          double pane:  U~1.8-2.8  SHGC~0.4-0.6
+          triple pane:  U~0.8-1.4  SHGC~0.3-0.5
+        This simplified model is numerically robust and never triggers
+        EnergyPlus convergence errors.
 
         Args:
             name: Unique material name.
@@ -179,20 +189,21 @@ def make_material_tools(config: ConfigState) -> list[BaseTool]:
     ) -> str:
         """Create a TRUE per-pane glass layer (WindowMaterial:Glazing).
 
-        Unlike create_glazing_material (which collapses a whole window into a
-        U/SHGC/VT equivalent and MUST be the only layer), this defines a real
-        single glass pane with thickness and per-pane optical/thermal
-        properties. It can be composed with create_airgap_material in a
-        multi-layer Construction to model double/triple glazing legally:
+        DEPRECATED — prefer create_glazing_material instead.
 
-            create_construction(
-                name="Window_Double_Clear",
-                layers=["Clear_Glass_3mm", "Air_Gap_13mm", "Clear_Glass_3mm"],
-            )
+        This tool creates a per-pane glass layer whose 13+ optical fields
+        frequently cause EnergyPlus to crash with a Fatal "Convergence error
+        in SolveForWindowTemperatures". For virtually all window specs you
+        should use create_glazing_material (a WindowMaterial:SimpleGlazingSystem
+        that takes only U-factor / SHGC / VT and never triggers convergence
+        failures).
 
-        EnergyPlus needs this per-pane data to solve window surface
-        temperatures; SimpleGlazingSystem in a multi-layer assembly makes it
-        abort with a Fatal convergence error.
+        Use this tool ONLY when the spec explicitly provides per-pane optical
+        data (glass thickness, solar transmittance, visible transmittance,
+        reflectance, AND emissivity for each individual pane). For "double
+        pane" / "triple pane" / "low-e" / "clear glass" specs that give only a
+        whole-window U-factor or qualitative description, use
+        create_glazing_material instead.
 
         Args:
             name: Unique material name.
@@ -209,7 +220,27 @@ def make_material_tools(config: ConfigState) -> list[BaseTool]:
         """
         if idf.has("WindowMaterial:Glazing", name):
             return _err(f"WindowMaterial:Glazing '{name}' already exists.")
-        try:
+        # Hard guard: per-pane WindowMaterial:Glazing with LLM-generated
+        # optical parameters frequently makes EnergyPlus's
+        # SolveForWindowTemperatures fail to converge (Fatal abort). The
+        # simplified create_glazing_material (WindowMaterial:SimpleGlazingSystem)
+        # has the same thermal behavior at the whole-window level and never
+        # triggers this. Force the LLM onto the safe path — it must call
+        # create_glazing_material with an equivalent U-factor/SHGC instead.
+        return _err(
+            "create_glazing_layer_material is disabled to prevent EnergyPlus "
+            "convergence failures. The per-pane WindowMaterial:Glazing model "
+            "requires optical parameters that are very hard to get right and "
+            "frequently crash EnergyPlus with 'Convergence error in "
+            "SolveForWindowTemperatures'. Instead use create_glazing_material "
+            "(WindowMaterial:SimpleGlazingSystem) with an equivalent whole-"
+            "window U-factor and SHGC. Typical values: single pane U~5.8 "
+            "SHGC~0.78; double pane U~1.8-2.8 SHGC~0.4-0.6; triple pane "
+            "U~0.8-1.4 SHGC~0.3-0.5. Then make the window construction use "
+            "this SimpleGlazingSystem as its SOLE layer.",
+            data={"hint": "use create_glazing_material instead"},
+        )
+        try:  # pragma: no cover - unreachable while the guard above is active
             idf.add(WindowMaterialGlazing(
                 name=name,
                 optical_data_type="SpectralAverage",

--- a/src/agent/tools/material_tools.py
+++ b/src/agent/tools/material_tools.py
@@ -5,6 +5,7 @@ from idfpy.models.constructions import (
     Material,
     MaterialAirGap,
     MaterialNoMass,
+    WindowMaterialGlazing,
     WindowMaterialSimpleGlazingSystem,
 )
 from langchain_core.tools import BaseTool, tool
@@ -17,6 +18,7 @@ _ALL_MATERIAL_TYPES = [
     "Material:NoMass",
     "Material:AirGap",
     "WindowMaterial:SimpleGlazingSystem",
+    "WindowMaterial:Glazing",
 ]
 
 
@@ -159,6 +161,80 @@ def make_material_tools(config: ConfigState) -> list[BaseTool]:
             return _err(f"Error creating glazing material '{name}': {e}")
 
     @tool
+    def create_glazing_layer_material(
+        name: str,
+        thickness: float,
+        solar_transmittance: float,
+        visible_transmittance: float,
+        conductivity: float,
+        front_solar_reflectance: float = 0.07,
+        back_solar_reflectance: float = 0.07,
+        front_visible_reflectance: float = 0.08,
+        back_visible_reflectance: float = 0.08,
+        infrared_transmittance: float = 0.0,
+        front_emissivity: float = 0.84,
+        back_emissivity: float = 0.84,
+        dirt_correction_factor: float = 1.0,
+        solar_diffusing: str = "No",
+    ) -> str:
+        """Create a TRUE per-pane glass layer (WindowMaterial:Glazing).
+
+        Unlike create_glazing_material (which collapses a whole window into a
+        U/SHGC/VT equivalent and MUST be the only layer), this defines a real
+        single glass pane with thickness and per-pane optical/thermal
+        properties. It can be composed with create_airgap_material in a
+        multi-layer Construction to model double/triple glazing legally:
+
+            create_construction(
+                name="Window_Double_Clear",
+                layers=["Clear_Glass_3mm", "Air_Gap_13mm", "Clear_Glass_3mm"],
+            )
+
+        EnergyPlus needs this per-pane data to solve window surface
+        temperatures; SimpleGlazingSystem in a multi-layer assembly makes it
+        abort with a Fatal convergence error.
+
+        Args:
+            name: Unique material name.
+            thickness: Pane thickness, meters, > 0 (e.g. 0.003 for 3mm).
+            solar_transmittance: Solar transmittance at normal incidence, 0-1.
+            visible_transmittance: Visible transmittance at normal incidence, 0-1.
+            conductivity: Glass conductivity, W/(m*K) (~1.0 for clear glass).
+            front_solar_reflectance / back_solar_reflectance: 0-1.
+            front_visible_reflectance / back_visible_reflectance: 0-1.
+            infrared_transmittance: IR transmittance at normal incidence, 0-1.
+            front_emissivity / back_emissivity: IR hemispherical emissivity, 0-1.
+            dirt_correction_factor: 0.5-1.0 (1.0 = clean).
+            solar_diffusing: "Yes" or "No".
+        """
+        if idf.has("WindowMaterial:Glazing", name):
+            return _err(f"WindowMaterial:Glazing '{name}' already exists.")
+        try:
+            idf.add(WindowMaterialGlazing(
+                name=name,
+                optical_data_type="SpectralAverage",
+                thickness=thickness,
+                solar_transmittance_at_normal_incidence=solar_transmittance,
+                front_side_solar_reflectance_at_normal_incidence=front_solar_reflectance,
+                back_side_solar_reflectance_at_normal_incidence=back_solar_reflectance,
+                visible_transmittance_at_normal_incidence=visible_transmittance,
+                front_side_visible_reflectance_at_normal_incidence=front_visible_reflectance,
+                back_side_visible_reflectance_at_normal_incidence=back_visible_reflectance,
+                infrared_transmittance_at_normal_incidence=infrared_transmittance,
+                front_side_infrared_hemispherical_emissivity=front_emissivity,
+                back_side_infrared_hemispherical_emissivity=back_emissivity,
+                conductivity=conductivity,
+                dirt_correction_factor_for_solar_and_visible_transmittance=dirt_correction_factor,
+                solar_diffusing=solar_diffusing,
+            ))
+            return _ok(
+                f"WindowMaterial:Glazing '{name}' created successfully.",
+                idf.get("WindowMaterial:Glazing", name).model_dump(),
+            )
+        except Exception as e:
+            return _err(f"Error creating glazing layer material '{name}': {e}")
+
+    @tool
     def list_materials() -> str:
         """List all materials."""
         items = []
@@ -275,6 +351,7 @@ def make_material_tools(config: ConfigState) -> list[BaseTool]:
         create_nomass_material,
         create_airgap_material,
         create_glazing_material,
+        create_glazing_layer_material,
         list_materials,
         get_material,
         update_material,

--- a/src/mcp/geometry.py
+++ b/src/mcp/geometry.py
@@ -1,0 +1,88 @@
+"""Neutral geometry helpers shared across the codebase.
+
+Lives in ``src/mcp`` so it can be imported by both ``src/mcp/state.py`` and
+``src/agent/tools/fenestration_tools.py`` without creating a circular import
+(``fenestration_tools`` already imports from ``src.mcp.state``).
+
+Two concerns are provided here:
+
+* ``surface_normal`` — unit outward normal of a planar polygon via Newell's
+  method. Robust to non-strictly-planar quads (it sums per-edge
+  contributions), which matches EnergyPlus' own surface-normal computation.
+* ``surface_vertices`` — read the (x, y, z) tuples from an idfpy
+  ``BuildingSurface:Detailed`` object, handling both the nested ``vertices``
+  list shape and the flat ``vertex_{i}_{axis}_coordinate`` fallback.
+"""
+
+from __future__ import annotations
+
+import math
+
+# Tolerance for a normal-direction dot product comparison. A surface whose
+# normal is essentially perpendicular to the expected axis (dot within
+# +/- this of zero) is treated as "sideways" and left untouched — only
+# clearly-wrong normals (e.g. a Floor pointing firmly up) are flipped.
+NORMAL_DOT_TOLERANCE = 0.01
+
+# Maximum allowed distance (m) from any vertex to a reference plane. Used by
+# callers (e.g. fenestration coplanarity check) to detect warped polygons;
+# 1 cm tolerates float rounding.
+COPLANARITY_TOLERANCE = 0.01
+
+
+def surface_normal(vertices: list[tuple[float, float, float]]) -> tuple[float, float, float]:
+    """Unit outward normal of a polygon via Newell's method.
+
+    Robust to non-strictly-planar quads (sums contributions per edge), so it
+    matches EnergyPlus' own surface-normal computation. Returns ``(0, 0, 0)``
+    for degenerate (collinear / duplicate) input.
+    """
+    nx = ny = nz = 0.0
+    n = len(vertices)
+    for i in range(n):
+        ax, ay, az = vertices[i]
+        bx, by, bz = vertices[(i + 1) % n]
+        nx += (ay - by) * (az + bz)
+        ny += (az - bz) * (ax + bx)
+        nz += (ax - bx) * (ay + by)
+    length = math.sqrt(nx * nx + ny * ny + nz * nz)
+    if length == 0.0:
+        return (0.0, 0.0, 0.0)  # degenerate (collinear / duplicate) vertices
+    return (nx / length, ny / length, nz / length)
+
+
+def surface_vertices(obj) -> list[tuple[float, float, float]]:
+    """Extract ``(x, y, z)`` tuples from an idfpy surface object.
+
+    Handles two storage shapes:
+
+    * ``BuildingSurface:Detailed`` stores geometry as a nested ``vertices``
+      list (each item has ``vertex_{x,y,z}_coordinate``).
+    * Some legacy/flat shapes store ``vertex_{i}_{x,y,z}_coordinate`` or
+      ``vertex_{x,y,z}_coordinate_{i}`` as direct attributes.
+
+    The nested list is tried first; the flat attributes are a defensive
+    fallback. Returns at least 3 points when available.
+    """
+    nested = getattr(obj, "vertices", None)
+    if nested:
+        pts = []
+        for item in nested:
+            x = getattr(item, "vertex_x_coordinate", None)
+            y = getattr(item, "vertex_y_coordinate", None)
+            z = getattr(item, "vertex_z_coordinate", None)
+            if x is not None and y is not None and z is not None:
+                pts.append((float(x), float(y), float(z)))
+        if len(pts) >= 3:
+            return pts
+
+    # Fallback: flat vertex_{i}_{axis}_coordinate attributes.
+    pts: dict[int, dict[str, float]] = {}
+    for i in range(1, 5):
+        for axis in ("x", "y", "z"):
+            val = getattr(obj, f"vertex_{i}_{axis}_coordinate", None)
+            if val is None:
+                val = getattr(obj, f"vertex_{axis}_coordinate_{i}", None)
+            if val is not None:
+                pts.setdefault(i, {})[axis] = float(val)
+    return [(pts[i]["x"], pts[i]["y"], pts[i]["z"]) for i in sorted(pts)]

--- a/src/mcp/state.py
+++ b/src/mcp/state.py
@@ -11,6 +11,7 @@ from idfpy.models.constructions import (
     Material,
     MaterialAirGap,
     MaterialNoMass,
+    WindowMaterialGlazing,
     WindowMaterialSimpleGlazingSystem,
 )
 from idfpy.models.hvac_templates import (
@@ -34,6 +35,11 @@ from idfpy.models.schedules import (
     ScheduleTypeLimits,
 )
 from idfpy.models.simulation import Building, SimulationControl, Timestep, Version
+from src.mcp.geometry import (
+    NORMAL_DOT_TOLERANCE,
+    surface_normal,
+    surface_vertices,
+)
 from idfpy.models.thermal_zones import (
     BuildingSurfaceDetailed,
     BuildingSurfaceDetailedVerticesItem,
@@ -264,7 +270,8 @@ class ConfigState(BaseSchema):
         try:
             return any(idf.all_of_type(t) for t in (
                 "Zone", "Material", "Material:NoMass", "Material:AirGap",
-                "WindowMaterial:SimpleGlazingSystem", "Construction",
+                "WindowMaterial:SimpleGlazingSystem", "WindowMaterial:Glazing",
+                "Construction",
                 "BuildingSurface:Detailed", "FenestrationSurface:Detailed",
                 "Schedule:Compact", "ScheduleTypeLimits",
                 "HVACTemplate:Thermostat", "HVACTemplate:Zone:IdealLoadsAirSystem",
@@ -395,6 +402,7 @@ class ConfigState(BaseSchema):
                 "Material:AirGap",
                 "MaterialAirGap",
                 "WindowMaterial:SimpleGlazingSystem",
+                "WindowMaterial:Glazing",
             ),
             "Construction": ("Construction",),
             "BuildingSurface:Detailed": ("BuildingSurface:Detailed",),
@@ -537,6 +545,7 @@ class ConfigState(BaseSchema):
                     "Material:AirGap",
                     "MaterialAirGap",
                     "WindowMaterial:SimpleGlazingSystem",
+                    "WindowMaterial:Glazing",
                 )
             ),
             constructions_count=len(
@@ -572,16 +581,35 @@ class ConfigState(BaseSchema):
                 "Material:AirGap",
                 "MaterialAirGap",
                 "WindowMaterial:SimpleGlazingSystem",
+                "WindowMaterial:Glazing",
             )
         }
         # Glazing (window) material names only. EnergyPlus treats a
         # construction as a "window construction" iff at least one of its
-        # layers is a WindowMaterial:* object — here SimpleGlazingSystem is
-        # the only variant the agent creates. Used to flag fenestrations
+        # layers is a WindowMaterial:* object — the agent may create either
+        # SimpleGlazingSystem (whole-window equivalent) or Glazing (a true
+        # per-pane glass layer). Used to flag fenestrations
         # (Window / GlassDoor / TubularDaylight*) whose construction is
         # opaque, which makes EnergyPlus abort with "has an opaque surface
         # construction; it should have a window construction".
         glazing_material_names = {
+            getattr(obj, "name", "")
+            for obj in _idf_values(
+                self.idf,
+                "WindowMaterial:SimpleGlazingSystem",
+                "WindowMaterial:Glazing",
+            )
+        }
+        # SimpleGlazingSystem is a WHOLE-WINDOW model: it collapses the entire
+        # fenestration into a single U-factor/SHGC/VT. It therefore must be
+        # the ONLY layer of a Construction. Combining it with other layers
+        # (e.g. Glass + AirGap + Glass) gives EnergyPlus no per-pane optical
+        # data, so SolveForWindowTemperatures diverges and the run aborts
+        # with a Fatal "Convergence error ... new temperature = NaN". Window
+        # Material:Glazing, by contrast, is a real per-pane layer and may be
+        # composed with gas gaps in multi-pane assemblies. Names only; used
+        # by the sole-layer check below.
+        simple_glazing_names = {
             getattr(obj, "name", "")
             for obj in _idf_values(self.idf, "WindowMaterial:SimpleGlazingSystem")
         }
@@ -636,12 +664,42 @@ class ConfigState(BaseSchema):
         }
 
         for const in _idf_values(self.idf, "Construction"):
-            for field in layer_fields:
-                layer = getattr(const, field, None)
+            const_layers = [
+                getattr(const, lf, None) for lf in layer_fields
+            ]
+            for layer in const_layers:
                 if layer and layer not in material_names:
                     errors.append(
                         f"Construction '{const.name}' references material '{layer}' which does not exist."
                     )
+            # SimpleGlazingSystem is a whole-window equivalent (U/SHGC/VT
+            # only). If it appears as one of several layers, EnergyPlus
+            # cannot solve per-pane glass temperatures and aborts with a
+            # Fatal convergence error. Require it to be the sole layer.
+            # The error is prefixed "Construction '" so _ERROR_PATTERNS
+            # routes it to the construction phase for self-repair. A
+            # multi-pane window should instead use WindowMaterial:Glazing
+            # layers (create_glazing_layer_material), which carry true
+            # per-pane optical/thermal data and may be composed with gas gaps.
+            simple_layers = [
+                layer for layer in const_layers
+                if layer and layer in simple_glazing_names
+            ]
+            if simple_layers and any(
+                layer for layer in const_layers if layer not in simple_glazing_names
+            ):
+                errors.append(
+                    f"Construction '{const.name}' uses WindowMaterial:"
+                    f"SimpleGlazingSystem ({', '.join(simple_layers)}) together "
+                    f"with other layers. SimpleGlazingSystem is a whole-window "
+                    f"model (U/SHGC/VT only) and must be the ONLY layer — "
+                    f"combining it with gas gaps / extra panes makes EnergyPlus "
+                    f"abort with a Fatal convergence error. Either rebuild this "
+                    f"construction as a single SimpleGlazingSystem layer, or "
+                    f"replace the per-pane glass with WindowMaterial:Glazing "
+                    f"(create_glazing_layer_material) which can be composed "
+                    f"with Material:AirGap in a multi-pane assembly."
+                )
 
         for surface in _idf_values(self.idf, "BuildingSurface:Detailed"):
             if surface.construction_name not in construction_names:
@@ -652,6 +710,30 @@ class ConfigState(BaseSchema):
                 errors.append(
                     f"Surface '{surface.name}' references zone '{surface.zone_name}' which does not exist."
                 )
+            # Auto-correct flipped Floor / Roof / Ceiling normals. EnergyPlus
+            # expects (under the Counterclockwise vertex-entry convention) a
+            # Floor's outward normal to point DOWN (tilt 180) and a
+            # Roof/Ceiling's to point UP (tilt 0). When the LLM lists floor
+            # corners in plan-view CCW order the normal ends up pointing +Z,
+            # which EnergyPlus flags as "Floor is upside down! Tilt=0.0,
+            # should be near 180". We silently reverse the vertex order to
+            # flip the normal — no error, no repair round (mirrors how window
+            # normals are auto-aligned in fenestration_tools). Tolerates near-
+            # horizontal surfaces; only clearly-wrong normals are flipped.
+            if surface.surface_type in ("Floor", "Roof", "Ceiling"):
+                verts = surface_vertices(surface)
+                if len(verts) >= 3:
+                    nx, ny, nz = surface_normal(verts)
+                    # Only flip when the normal is decisively off the expected
+                    # vertical axis (|z| well above the tolerance), so a
+                    # tilted/sloped surface is left untouched.
+                    flipped = False
+                    if surface.surface_type == "Floor" and nz > NORMAL_DOT_TOLERANCE:
+                        flipped = True
+                    elif surface.surface_type in ("Roof", "Ceiling") and nz < -NORMAL_DOT_TOLERANCE:
+                        flipped = True
+                    if flipped and getattr(surface, "vertices", None):
+                        surface.vertices.reverse()
 
         # Fenestration surface_types that EnergyPlus requires to be backed by
         # a window (glazing) construction. A plain Door is the only type that
@@ -971,6 +1053,7 @@ class ConfigState(BaseSchema):
                 "Material:AirGap",
                 "MaterialAirGap",
                 "WindowMaterial:SimpleGlazingSystem",
+                "WindowMaterial:Glazing",
             ):
                 continue
             if material_type == "Standard":
@@ -1004,20 +1087,71 @@ class ConfigState(BaseSchema):
                     )
                 )
             elif material_type == "Glazing":
-                self.idf.add(
-                    WindowMaterialSimpleGlazingSystem(
-                        name=name,
-                        u_factor=_get(raw, "U-Factor", "U Factor"),
-                        solar_heat_gain_coefficient=_get(
-                            raw,
-                            "Solar_Heat_Gain_Coefficient",
-                            "Solar Heat Gain Coefficient",
-                        ),
-                        visible_transmittance=_get(
-                            raw, "Visible_Transmittance", "Visible Transmittance"
-                        ),
-                    )
-                )
+                self.idf.add(WindowMaterialSimpleGlazingSystem(
+                    name=name,
+                    u_factor=_get(raw, "U-Factor", "U Factor"),
+                    solar_heat_gain_coefficient=_get(
+                        raw,
+                        "Solar_Heat_Gain_Coefficient",
+                        "Solar Heat Gain Coefficient",
+                    ),
+                    visible_transmittance=_get(raw, "Visible_Transmittance", "Visible Transmittance"),
+                ))
+            elif material_type == "GlazingLayer":
+                # A true per-pane glass layer (WindowMaterial:Glazing). Unlike
+                # the whole-window SimpleGlazingSystem above, this carries
+                # thickness + optical/thermal data per pane and MAY be composed
+                # with gas gaps in multi-pane assemblies. optical_data_type is
+                # fixed to SpectralAverage for the simplified YAML path.
+                self.idf.add(WindowMaterialGlazing(**_clean_kwargs({
+                    "name": name,
+                    "optical_data_type": _get(
+                        raw, "Optical_Data_Type", "Optical Data Type",
+                        default="SpectralAverage",
+                    ),
+                    "thickness": _get(raw, "Thickness"),
+                    "solar_transmittance_at_normal_incidence": _get(
+                        raw, "Solar_Transmittance_at_Normal_Incidence",
+                        "Solar Transmittance at Normal Incidence",
+                    ),
+                    "front_side_solar_reflectance_at_normal_incidence": _get(
+                        raw, "Front_Side_Solar_Reflectance_at_Normal_Incidence",
+                        "Front Side Solar Reflectance at Normal Incidence",
+                    ),
+                    "back_side_solar_reflectance_at_normal_incidence": _get(
+                        raw, "Back_Side_Solar_Reflectance_at_Normal_Incidence",
+                        "Back Side Solar Reflectance at Normal Incidence",
+                    ),
+                    "visible_transmittance_at_normal_incidence": _get(
+                        raw, "Visible_Transmittance_at_Normal_Incidence",
+                        "Visible Transmittance at Normal Incidence",
+                    ),
+                    "front_side_visible_reflectance_at_normal_incidence": _get(
+                        raw, "Front_Side_Visible_Reflectance_at_Normal_Incidence",
+                        "Front Side Visible Reflectance at Normal Incidence",
+                    ),
+                    "back_side_visible_reflectance_at_normal_incidence": _get(
+                        raw, "Back_Side_Visible_Reflectance_at_Normal_Incidence",
+                        "Back Side Visible Reflectance at Normal Incidence",
+                    ),
+                    "infrared_transmittance_at_normal_incidence": _get(
+                        raw, "Infrared_Transmittance_at_Normal_Incidence",
+                        "Infrared Transmittance at Normal Incidence",
+                    ),
+                    "front_side_infrared_hemispherical_emissivity": _get(
+                        raw, "Front_Side_Infrared_Hemispherical_Emissivity",
+                        "Front Side Infrared Hemispherical Emissivity",
+                    ),
+                    "back_side_infrared_hemispherical_emissivity": _get(
+                        raw, "Back_Side_Infrared_Hemispherical_Emissivity",
+                        "Back Side Infrared Hemispherical Emissivity",
+                    ),
+                    "conductivity": _get(raw, "Conductivity"),
+                    "dirt_correction_factor": _get(
+                        raw, "Dirt_Correction_Factor", "Dirt Correction Factor",
+                    ),
+                    "solar_diffusing": _get(raw, "Solar_Diffusing", "Solar Diffusing"),
+                })))
 
     def _add_constructions(self, data: dict[str, Any]) -> None:
         layer_fields = [

--- a/src/mcp/state.py
+++ b/src/mcp/state.py
@@ -572,9 +572,38 @@ class ConfigState(BaseSchema):
                 "WindowMaterial:SimpleGlazingSystem",
             )
         }
+        # Glazing (window) material names only. EnergyPlus treats a
+        # construction as a "window construction" iff at least one of its
+        # layers is a WindowMaterial:* object — here SimpleGlazingSystem is
+        # the only variant the agent creates. Used to flag fenestrations
+        # (Window / GlassDoor / TubularDaylight*) whose construction is
+        # opaque, which makes EnergyPlus abort with "has an opaque surface
+        # construction; it should have a window construction".
+        glazing_material_names = {
+            getattr(obj, "name", "")
+            for obj in _idf_values(self.idf, "WindowMaterial:SimpleGlazingSystem")
+        }
+        # Construction layer fields (outside_layer + layer_2..layer_10).
+        # Defined once here so both the glazing-construction computation and
+        # the dangling-material check below share it.
+        layer_fields = [
+            "outside_layer",
+            "layer_2", "layer_3", "layer_4", "layer_5",
+            "layer_6", "layer_7", "layer_8", "layer_9", "layer_10",
+        ]
         construction_names = {
             getattr(obj, "name", "") for obj in _idf_values(self.idf, "Construction")
         }
+        # Constructions that qualify as "window constructions" — at least one
+        # layer points at a WindowMaterial:SimpleGlazingSystem. Computed once
+        # here so the fenestration check below is O(1) per surface.
+        glazing_construction_names: set[str] = set()
+        for const in _idf_values(self.idf, "Construction"):
+            for lf in layer_fields:
+                layer = getattr(const, lf, None)
+                if layer and layer in glazing_material_names:
+                    glazing_construction_names.add(const.name)
+                    break
         surface_names = {
             getattr(obj, "name", "")
             for obj in _idf_values(self.idf, "BuildingSurface:Detailed")
@@ -589,18 +618,6 @@ class ConfigState(BaseSchema):
             for obj in _idf_values(self.idf, "HVACTemplate:Thermostat")
         }
 
-        layer_fields = [
-            "outside_layer",
-            "layer_2",
-            "layer_3",
-            "layer_4",
-            "layer_5",
-            "layer_6",
-            "layer_7",
-            "layer_8",
-            "layer_9",
-            "layer_10",
-        ]
         for const in _idf_values(self.idf, "Construction"):
             for field in layer_fields:
                 layer = getattr(const, field, None)
@@ -619,10 +636,31 @@ class ConfigState(BaseSchema):
                     f"Surface '{surface.name}' references zone '{surface.zone_name}' which does not exist."
                 )
 
+        # Fenestration surface_types that EnergyPlus requires to be backed by
+        # a window (glazing) construction. A plain Door is the only type that
+        # may use an opaque construction.
+        _glazing_surface_types = {
+            "Window", "GlassDoor", "TubularDaylightDiffuser", "TubularDaylightDome",
+        }
         for fen in _idf_values(self.idf, "FenestrationSurface:Detailed"):
             if fen.construction_name not in construction_names:
                 errors.append(
                     f"Fenestration '{fen.name}' references construction '{fen.construction_name}' which does not exist."
+                )
+            elif (
+                fen.surface_type in _glazing_surface_types
+                and fen.construction_name not in glazing_construction_names
+            ):
+                # EnergyPlus aborts: "FenestrationSurface:Detailed has an
+                # opaque surface construction; it should have a window
+                # construction". The construction owns the layer composition,
+                # so this is routed at construction via _ERROR_PATTERNS.
+                errors.append(
+                    f"Construction '{fen.construction_name}' is referenced by "
+                    f"fenestration '{fen.name}' ({fen.surface_type}) but has no "
+                    f"WindowMaterial layer — it is opaque. Rebuild this "
+                    f"construction to use a WindowMaterial:SimpleGlazingSystem "
+                    f"glazing layer."
                 )
             if fen.building_surface_name not in surface_names:
                 errors.append(

--- a/src/mcp/state.py
+++ b/src/mcp/state.py
@@ -539,7 +539,9 @@ class ConfigState(BaseSchema):
                     "WindowMaterial:SimpleGlazingSystem",
                 )
             ),
-            constructions_count=len(_idf_values(self.idf, "Construction")),
+            constructions_count=len(
+                _idf_values(self.idf, "Construction", "Construction:AirBoundary")
+            ),
             surfaces_count=len(_idf_values(self.idf, "BuildingSurface:Detailed")),
             fenestrations_count=len(
                 _idf_values(self.idf, "FenestrationSurface:Detailed")
@@ -592,7 +594,8 @@ class ConfigState(BaseSchema):
             "layer_6", "layer_7", "layer_8", "layer_9", "layer_10",
         ]
         construction_names = {
-            getattr(obj, "name", "") for obj in _idf_values(self.idf, "Construction")
+            getattr(obj, "name", "")
+            for obj in _idf_values(self.idf, "Construction", "Construction:AirBoundary")
         }
         # Constructions that qualify as "window constructions" — at least one
         # layer points at a WindowMaterial:SimpleGlazingSystem. Computed once
@@ -664,6 +667,11 @@ class ConfigState(BaseSchema):
             elif (
                 fen.surface_type in _glazing_surface_types
                 and fen.construction_name not in glazing_construction_names
+                # An AirBoundary construction is the legitimate construction
+                # for interior windows/glass-doors (open-air passage between
+                # zones); it has no WindowMaterial, so the glazing check must
+                # NOT flag it. The dedicated interzone check below governs it.
+                and fen.construction_name not in airboundary_construction_names
             ):
                 # EnergyPlus aborts: "FenestrationSurface:Detailed has an
                 # opaque surface construction; it should have a window
@@ -690,13 +698,14 @@ class ConfigState(BaseSchema):
                 # Outside Boundary Condition Object blank, which EnergyPlus
                 # rejects ("invalid blank Outside Boundary Condition Object").
                 # The fix is to model the interior door/window with a
-                # Construction:AirBoundary. Routed to fenestration (which owns
-                # the construction_name pointer); construction may need to
-                # create the AirBoundary first via a back-hop.
+                # Construction:AirBoundary. Routed to construction (which owns
+                # construction creation — only it can build the AirBoundary);
+                # the error string starts with "Construction '" so _ERROR_PATTERNS
+                # matches the ("Construction '", "construction") rule.
                 errors.append(
-                    f"Fenestration '{fen.name}' is on interior wall "
-                    f"'{fen.building_surface_name}' (Surface boundary) but uses "
-                    f"construction '{fen.construction_name}' which is not a "
+                    f"Construction '{fen.construction_name}' used by fenestration "
+                    f"'{fen.name}' on interior wall "
+                    f"'{fen.building_surface_name}' (Surface boundary) is not a "
                     f"Construction:AirBoundary. Interior subsurfaces must use "
                     f"a Construction:AirBoundary (open-air) construction."
                 )

--- a/src/mcp/state.py
+++ b/src/mcp/state.py
@@ -604,8 +604,22 @@ class ConfigState(BaseSchema):
                 if layer and layer in glazing_material_names:
                     glazing_construction_names.add(const.name)
                     break
+        # Layer-less open-air constructions used on interior subsurfaces
+        # (doors/windows between two zones) to avoid the "invalid blank
+        # Outside Boundary Condition Object" severe error. A subsurface on a
+        # 'Surface'-boundary parent must be one of these.
+        airboundary_construction_names = {
+            getattr(obj, "name", "")
+            for obj in _idf_values(self.idf, "Construction:AirBoundary")
+        }
         surface_names = {
             getattr(obj, "name", "")
+            for obj in _idf_values(self.idf, "BuildingSurface:Detailed")
+        }
+        # Parent surface name -> its outside boundary condition, so the
+        # fenestration check can tell interior ('Surface') parents apart.
+        surface_boundary: dict[str, str] = {
+            getattr(obj, "name", ""): getattr(obj, "outside_boundary_condition", "")
             for obj in _idf_values(self.idf, "BuildingSurface:Detailed")
         }
         zone_names = {getattr(obj, "name", "") for obj in _idf_values(self.idf, "Zone")}
@@ -665,6 +679,26 @@ class ConfigState(BaseSchema):
             if fen.building_surface_name not in surface_names:
                 errors.append(
                     f"Fenestration '{fen.name}' references building surface '{fen.building_surface_name}' which does not exist."
+                )
+            elif (
+                surface_boundary.get(fen.building_surface_name) == "Surface"
+                and fen.construction_name not in airboundary_construction_names
+                and not getattr(fen, "outside_boundary_condition_object", None)
+            ):
+                # Parent is a zone-separating wall ('Surface' boundary). A
+                # regular layered subsurface construction here leaves its own
+                # Outside Boundary Condition Object blank, which EnergyPlus
+                # rejects ("invalid blank Outside Boundary Condition Object").
+                # The fix is to model the interior door/window with a
+                # Construction:AirBoundary. Routed to fenestration (which owns
+                # the construction_name pointer); construction may need to
+                # create the AirBoundary first via a back-hop.
+                errors.append(
+                    f"Fenestration '{fen.name}' is on interior wall "
+                    f"'{fen.building_surface_name}' (Surface boundary) but uses "
+                    f"construction '{fen.construction_name}' which is not a "
+                    f"Construction:AirBoundary. Interior subsurfaces must use "
+                    f"a Construction:AirBoundary (open-air) construction."
                 )
 
         for ils in _idf_values(self.idf, "HVACTemplate:Zone:IdealLoadsAirSystem"):

--- a/tests/test_glazing_construction_detection.py
+++ b/tests/test_glazing_construction_detection.py
@@ -1,0 +1,158 @@
+"""Regression test: _is_glazing_construction must recognize BOTH window
+material variants, not just SimpleGlazingSystem.
+
+The original implementation only checked ``idf.has("WindowMaterial:
+SimpleGlazingSystem", layer)``, which wrongly classified a valid multi-pane
+window built from WindowMaterial:Glazing layers (created via
+create_glazing_layer_material) as "opaque". create_fenestration then
+refused to create the fenestration — silently dropping every window in the
+model. This was the root cause of the 0-window result across all 10 office
+test cases: material and construction phases built the glazing correctly,
+but fenestration_tools rejected it.
+
+EnergyPlus accepts two window-material types as qualifying a construction
+as glazing:
+  - WindowMaterial:SimpleGlazingSystem (whole-window U/SHGC/VT model)
+  - WindowMaterial:Glazing (true per-pane glass layer)
+"""
+
+from idfpy.models.constructions import (
+    Construction,
+    Material,
+    WindowMaterialGlazing,
+    WindowMaterialSimpleGlazingSystem,
+)
+from idfpy.models.thermal_zones import (
+    BuildingSurfaceDetailed,
+    BuildingSurfaceDetailedVerticesItem,
+    FenestrationSurfaceDetailed,
+    Zone,
+)
+
+from src.agent.tools.fenestration_tools import _is_glazing_construction
+from src.mcp.state import ConfigState, _idf_values
+
+_VERTS = [
+    BuildingSurfaceDetailedVerticesItem(
+        vertex_x_coordinate=0.0, vertex_y_coordinate=0.0, vertex_z_coordinate=0.0
+    )
+] * 3
+
+
+def _state() -> ConfigState:
+    return ConfigState()
+
+
+def _make_glazing_layer(name="Clear_Glass_3mm"):
+    """Build a valid WindowMaterial:Glazing per-pane layer."""
+    return WindowMaterialGlazing(
+        name=name,
+        optical_data_type="SpectralAverage",
+        thickness=0.003,
+        solar_transmittance_at_normal_incidence=0.83,
+        front_side_solar_reflectance_at_normal_incidence=0.07,
+        back_side_solar_reflectance_at_normal_incidence=0.07,
+        visible_transmittance_at_normal_incidence=0.90,
+        front_side_visible_reflectance_at_normal_incidence=0.08,
+        back_side_visible_reflectance_at_normal_incidence=0.08,
+        infrared_transmittance_at_normal_incidence=0.0,
+        front_side_infrared_hemispherical_emissivity=0.84,
+        back_side_infrared_hemispherical_emissivity=0.84,
+        conductivity=1.0,
+    )
+
+
+def test_simple_glazing_construction_is_detected():
+    """A construction whose sole layer is WindowMaterial:SimpleGlazingSystem
+    must be detected as glazing (the case the original code handled)."""
+    s = _state()
+    s.idf.add(WindowMaterialSimpleGlazingSystem(
+        name="Win_Simple", u_factor=1.8,
+        solar_heat_gain_coefficient=0.4, visible_transmittance=0.7,
+    ))
+    s.idf.add(Construction(name="Win_Const_Simple", outside_layer="Win_Simple"))
+
+    assert _is_glazing_construction(s.idf, "Win_Const_Simple") is True
+
+
+def test_per_pane_glazing_construction_is_detected():
+    """A multi-pane construction whose layers include WindowMaterial:Glazing
+    (created via create_glazing_layer_material) MUST also be detected as
+    glazing. This is the regression case — the original code returned False
+    here, rejecting every multi-pane window."""
+    s = _state()
+    s.idf.add(_make_glazing_layer("Clear_Glass_3mm"))
+    s.idf.add(Material(
+        name="Air_Gap_13mm", roughness="rough", thickness=0.013,
+        conductivity=0.026, density=1.2, specific_heat=1005.0,
+    ))
+    # Double-pane window: glass + air gap + glass
+    s.idf.add(Construction(
+        name="Win_Double_Pane", outside_layer="Clear_Glass_3mm",
+        layer_2="Air_Gap_13mm", layer_3="Clear_Glass_3mm",
+    ))
+
+    assert _is_glazing_construction(s.idf, "Win_Double_Pane") is True
+
+
+def test_opaque_construction_is_not_detected_as_glazing():
+    """A construction with only opaque Material layers must NOT be detected
+    as glazing (the legitimate rejection case)."""
+    s = _state()
+    s.idf.add(Material(
+        name="Brick", roughness="rough", thickness=0.1,
+        conductivity=0.7, density=1400.0, specific_heat=840.0,
+    ))
+    s.idf.add(Construction(name="Wall_Const", outside_layer="Brick"))
+
+    assert _is_glazing_construction(s.idf, "Wall_Const") is False
+
+
+def test_nonexistent_construction_is_not_glazing():
+    """A missing construction name must return False, not raise."""
+    s = _state()
+    assert _is_glazing_construction(s.idf, "Does_Not_Exist") is False
+
+
+def test_create_fenestration_accepts_per_pane_glazing_construction():
+    """End-to-end: create_fenestration must ACCEPT a window whose
+    construction uses WindowMaterial:Glazing layers (the scenario that
+    failed in production with "Construction 'X' is opaque"). This is the
+    user-visible behavior the fix restores."""
+    from src.agent.tools import make_fenestration_tools
+
+    s = _state()
+    s.idf.add(_make_glazing_layer("Glazing_Layer"))
+    s.idf.add(Construction(name="Win_Const", outside_layer="Glazing_Layer"))
+    s.idf.add(Zone(name="Z1"))
+    s.idf.add(BuildingSurfaceDetailed(
+        name="South_Wall", surface_type="Wall", construction_name="Win_Const",
+        zone_name="Z1", outside_boundary_condition="Outdoors",
+        sun_exposure="SunExposed", wind_exposure="WindExposed",
+        vertices=[
+            BuildingSurfaceDetailedVerticesItem(vertex_x_coordinate=0.0, vertex_y_coordinate=0.0, vertex_z_coordinate=0.0),
+            BuildingSurfaceDetailedVerticesItem(vertex_x_coordinate=5.0, vertex_y_coordinate=0.0, vertex_z_coordinate=0.0),
+            BuildingSurfaceDetailedVerticesItem(vertex_x_coordinate=5.0, vertex_y_coordinate=0.0, vertex_z_coordinate=3.0),
+            BuildingSurfaceDetailedVerticesItem(vertex_x_coordinate=0.0, vertex_y_coordinate=0.0, vertex_z_coordinate=3.0),
+        ],
+    ))
+
+    tools = make_fenestration_tools(s)
+    create_fen = [t for t in tools if t.name == "create_fenestration"][0]
+    result = create_fen.invoke({
+        "name": "South_Window", "surface_type": "Window",
+        "construction_name": "Win_Const", "building_surface_name": "South_Wall",
+        "vertices": [
+            {"X": 1.0, "Y": 0.0, "Z": 1.0},
+            {"X": 4.0, "Y": 0.0, "Z": 1.0},
+            {"X": 4.0, "Y": 0.0, "Z": 2.5},
+            {"X": 1.0, "Y": 0.0, "Z": 2.5},
+        ],
+        "multiplier": 1,
+    })
+
+    import json
+    payload = json.loads(result)
+    assert payload["success"] is True, f"create_fenestration failed: {payload.get('message')}"
+    # The window must actually be in the IDF now.
+    assert len(_idf_values(s.idf, "FenestrationSurface:Detailed")) == 1


### PR DESCRIPTION
## Summary

- enforce glazing-compatible window constructions and SimpleGlazingSystem defaults
- align fenestration geometry with parent surfaces and correct floor/roof normals
- handle interior openings through Construction:AirBoundary
- block unsupported glazing-layer creation paths that caused EnergyPlus failures

## Stack

Depends on `feat/pr51-revision-backhop`. GitHub shows only the window-modeling layer in this diff.

## Validation

Window construction, geometry, and zero-output regression tests passed during branch reconstruction. The final stack passes pre-commit and all 67 offline tests.